### PR TITLE
Allow configuration of mailer templates directory

### DIFF
--- a/lib/activity_notification/mailers/helpers.rb
+++ b/lib/activity_notification/mailers/helpers.rb
@@ -120,8 +120,9 @@ module ActivityNotification
         #
         # @return [Array<String>] Template paths to find email view
         def template_paths
-          paths = ['activity_notification/mailer/default']
-          paths.unshift("activity_notification/mailer/#{@target.to_resources_name}") if @target.present?
+          dir = ActivityNotification.config.methods.include?(:mailer_templates_directory) ? ActivityNotification.config.mailer_templates_directory : 'activity_notification/mailer'
+          paths = ["#{dir}/default"]
+          paths.unshift("#{dir}/#{@target.to_resources_name}") if @target.present?
           paths
         end
 


### PR DESCRIPTION
This change would allow users to pick a custom folder to place their mailer templates in, rather than being forced to use "views/activity_notification/mailer". At the same time, users currently using the gem would not need to change their configuration file and everything would still work as normal.

My use case is probably fairly common: all of my views and controllers are namespaced (within the "public" folder), e.g., views for the public facing domain are within "views/public/notifications". Without this proposed change, I would either have to make activity notifications my one exception and place "activity_notification" views within the "views" folder directly, or I would have to completely reimplement the entire activity_notification mailer just so I can change the template paths. 

Any suggestions?