### PR TITLE
Fix README for controllers template

### DIFF
--- a/lib/generators/templates/controllers/README
+++ b/lib/generators/templates/controllers/README
@@ -6,8 +6,8 @@ Some setup you must do manually if you haven't yet:
   For example:
 
     Rails.application.routes.draw do
-      notify_to :users,                       controllers: 'users/notifications'
-      notify_to :admins, with_devise: :users, controllers: 'admins/notifications_with_devise'
+      notify_to :users,                       controller: 'users/notifications'
+      notify_to :admins, with_devise: :users, controller: 'admins/notifications_with_devise'
     end
 
 ===============================================================================


### PR DESCRIPTION
When wishing to use a custom notification controller, the controller name must be passed to the singular hash option `controller` in the `routes.rb` file.

See https://github.com/simukappu/activity_notification/blob/master/lib/activity_notification/rails/routes.rb for more details.

(Previously, the README for controllers template suggested passing the controller name to the **plural** hash option `controllers` -- but that does not work)