### PR TITLE
Update render method to use plain

### DIFF
--- a/lib/activity_notification/renderable.rb
+++ b/lib/activity_notification/renderable.rb
@@ -142,7 +142,7 @@ module ActivityNotification
     # @option params [Hash]           others                                  Parameters to be set as locals
     # @return [String] Rendered view or text as string
     def render(context, params = {})
-      params[:i18n] and return context.render text: self.text(params)
+      params[:i18n] and return context.render plain: self.text(params)
 
       partial = partial_path(*params.values_at(:partial, :partial_root, :target))
       layout  = layout_path(*params.values_at(:layout, :layout_root))

--- a/lib/activity_notification/renderable.rb
+++ b/lib/activity_notification/renderable.rb
@@ -8,7 +8,7 @@ module ActivityNotification
     #
     # @param [Hash] params Parameters for rendering notification text
     # @option params [String] :target Target type name to use as i18n text key
-    # @option params [Hash] others Parameters to be reffered in i18n text
+    # @option params [Hash] others Parameters to be referred in i18n text
     # @return [String] Rendered text
     def text(params = {})
       k = key.split('.')
@@ -88,7 +88,7 @@ module ActivityNotification
     #   <%= yield %>
     #
     # == Custom Layout Location
-    # 
+    #
     # You can customize the layout directory by supplying :layout_root
     # or by using an absolute path.
     #

--- a/spec/helpers/view_helpers_spec.rb
+++ b/spec/helpers/view_helpers_spec.rb
@@ -69,6 +69,14 @@ describe ActivityNotification::ViewHelpers, type: :helper do
       end
     end
 
+    context "with i18n param set" do
+      it "uses i18n text from key" do
+        notification.key = simple_text_key
+        expect(render_notification notification, i18n: { target: :text })
+          .to eq(simple_text_original)
+      end
+    end
+
     context "with custom view" do
       it "renders custom notification view for default target" do
         notification.key = 'custom.test'

--- a/spec/helpers/view_helpers_spec.rb
+++ b/spec/helpers/view_helpers_spec.rb
@@ -72,7 +72,7 @@ describe ActivityNotification::ViewHelpers, type: :helper do
     context "with i18n param set" do
       it "uses i18n text from key" do
         notification.key = simple_text_key
-        expect(render_notification notification, i18n: { target: :text })
+        expect(render_notification notification, i18n: true)
           .to eq(simple_text_original)
       end
     end


### PR DESCRIPTION
I was exploring the render options and noticed passing the `i18n` param (to bypass the partial rendering) was throwing a MissingTemplate error, this should get it more in line with the call in https://github.com/simukappu/activity_notification/compare/master...markedmondson:fix-i18n-render?expand=1#diff-2f0a0e25204a71bd80c120a836129462R155