### PR TITLE
Symbolize parameters for i18n interpolation

### DIFF
--- a/lib/activity_notification/renderable.rb
+++ b/lib/activity_notification/renderable.rb
@@ -21,7 +21,7 @@ module ActivityNotification
       k.push('text')
       k = k.join('.')
 
-      I18n.t(k, (parameters.merge(params) || {}).merge(
+      I18n.t(k, (parameters.symbolize_keys.merge(params) || {}).merge(
         group_member_count:          group_member_count,
         group_notification_count:    group_notification_count,
         group_member_notifier_count: group_member_notifier_count,

--- a/spec/helpers/view_helpers_spec.rb
+++ b/spec/helpers/view_helpers_spec.rb
@@ -67,6 +67,13 @@ describe ActivityNotification::ViewHelpers, type: :helper do
         expect(render_notification notification, fallback: :text)
           .to eq(simple_text_original)
       end
+
+      it "interpolates from parameters" do
+        notification.parameters = { "title" => "title" }
+        notification.key = 'article.update'
+        expect(render_notification notification, fallback: :text)
+          .to eq("Article title has been updated")
+      end
     end
 
     context "with custom view" do

--- a/spec/rails_app/config/locales/activity_notification.en.yml
+++ b/spec/rails_app/config/locales/activity_notification.en.yml
@@ -6,6 +6,8 @@ en:
       article:
         create:
           text: 'Article has been created'
+        update:
+          text: 'Article %{title} has been updated'
         destroy:
           text: 'Some user removed an article!'
       comment:


### PR DESCRIPTION
If parameters are stored on the notification record, they come back out from the DB as stringified keys so can't be used to interpolate the translation. I think this change will ensure the expected behaviour.