### PR TITLE
Allow pluralization of grouped notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,20 +507,25 @@ notification:
     article:
       create:
         text: 'Article has been created'
+      update:
+        text: 'Article %{article_title} has been updated'
       destroy:
         text: 'Some user removed an article!'
     comment:
       post:
-        text: "<p>%{notifier_name} posted comments to your article %{article_title}</p>"
+        text:
+          one: "<p>%{notifier_name} posted a comment on your article %{article_title}</p>"
+          other: "<p>%{notifier_name} posted %{count} comments on your article %{article_title}</p>"
       reply:
-        text: "<p>%{notifier_name} and %{group_member_count} other users replied for your comments</p>"
+        text: "<p>%{notifier_name} and %{group_member_count} other people replied %{group_notification_count} times to your comment</p>"
+        mail_subject: 'New comment on your article'
   admin:
     article:
       post:
         text: '[Admin] Article has been created'
 ```
 
-This structure is valid for notifications with keys *"notification.comment.reply"* or *"comment.reply"*. As mentioned before, *"notification."* part of the key is optional. In addition for above example, `%{notifier_name}` and `%{article_title}` are used from parameter field in the notification record.
+This structure is valid for notifications with keys *"notification.comment.reply"* or *"comment.reply"*. As mentioned before, *"notification."* part of the key is optional. In addition for above example, `%{notifier_name}` and `%{article_title}` are used from parameter field in the notification record. Pluralization is supported (but optional) for grouped notifications using the `%{group_notification_count}` value.
 
 ### Customizing controllers (optional)
 

--- a/lib/activity_notification/renderable.rb
+++ b/lib/activity_notification/renderable.rb
@@ -21,12 +21,16 @@ module ActivityNotification
       k.push('text')
       k = k.join('.')
 
-      I18n.t(k, (parameters.merge(params) || {}).merge(
+      attrs = (parameters.merge(params) || {}).merge(
         group_member_count:          group_member_count,
         group_notification_count:    group_notification_count,
         group_member_notifier_count: group_member_notifier_count,
         group_notifier_count:        group_notifier_count
-      ))
+      )
+
+      # Generate the :default fallback key without using pluralization key :count
+      default = I18n.t(k, attrs)
+      I18n.t(k, attrs.merge(count: group_notification_count, default: default))
     end
 
     # Renders notification from views.

--- a/spec/concerns/renderable_spec.rb
+++ b/spec/concerns/renderable_spec.rb
@@ -4,17 +4,23 @@ shared_examples_for :renderable do
   let(:test_instance) { create(test_class_name, target: test_target) }
   let(:target_type_key) { 'user' }
 
-  let(:notifier_name)        { 'foo' }
-  let(:article_title)        { 'bar' }
-  let(:group_member_count)   { 3 }
-  let(:simple_text_key)      { 'article.create' }
-  let(:params_text_key)      { 'comment.post' }
-  let(:group_text_key)       { 'comment.reply' }
-  let(:simple_text_original) { 'Article has been created' }
-  let(:params_text_original) { "<p>%{notifier_name} posted comments to your article %{article_title}</p>" }
-  let(:group_text_original)  { "<p>%{notifier_name} and %{group_member_count} people replied for your comments</p>" }
-  let(:params_text_embedded) { "<p>foo posted comments to your article bar</p>" }
-  let(:group_text_embedded)  { "<p>foo and 3 people replied for your comments</p>" }
+  let(:notifier_name)              { 'foo' }
+  let(:article_title)              { 'bar' }
+  let(:group_notification_count)   { 4 }
+  let(:group_member_count)         { 3 }
+  let(:simple_text_key)            { 'article.create' }
+  let(:params_text_key)            { 'article.update' }
+  let(:group_text_key)             { 'comment.reply' }
+  let(:plural_text_key)            { 'comment.post' }
+  let(:simple_text_original)       { 'Article has been created' }
+  let(:params_text_original)       { "Article %{article_title} has been updated" }
+  let(:plural_text_original_one)   { "<p>%{notifier_name} posted a comment on your article %{article_title}</p>" }
+  let(:plural_text_original_other) { "<p>%{notifier_name} posted %{count} comments on your article %{article_title}</p>" }
+  let(:group_text_original)        { "<p>%{notifier_name} and %{group_member_count} other people replied %{group_notification_count} times to your comment</p>" }
+  let(:params_text_embedded)       { "Article bar has been updated" }
+  let(:group_text_embedded)        { "<p>foo and 3 other people replied 4 times to your comment</p>" }
+  let(:plural_text_embedded_one)   { "<p>foo posted a comment on your article bar</p>" }
+  let(:plural_text_embedded_other) { "<p>foo posted 4 comments on your article bar</p>" }
 
   describe "i18n configuration" do
     it "has key configured for simple text" do
@@ -26,16 +32,29 @@ shared_examples_for :renderable do
       expect(I18n.t("notification.#{target_type_key}.#{params_text_key}.text"))
         .to eq(params_text_original)
       expect(I18n.t("notification.#{target_type_key}.#{params_text_key}.text",
-        {notifier_name: notifier_name, article_title: article_title}))
+        {article_title: article_title}))
         .to eq(params_text_embedded)
     end
 
-    it "has key configured with embedded params including group_member_count" do
+    it "has key configured with embedded params including group_member_count and group_notification_count" do
       expect(I18n.t("notification.#{target_type_key}.#{group_text_key}.text"))
         .to eq(group_text_original)
       expect(I18n.t("notification.#{target_type_key}.#{group_text_key}.text",
-        {notifier_name: notifier_name, group_member_count: group_member_count}))
+        {notifier_name: notifier_name, group_member_count: group_member_count, group_notification_count: group_notification_count}))
         .to eq(group_text_embedded)
+    end
+
+    it "has key configured with plurals" do
+      expect(I18n.t("notification.#{target_type_key}.#{plural_text_key}.text")[:one])
+        .to eq(plural_text_original_one)
+      expect(I18n.t("notification.#{target_type_key}.#{plural_text_key}.text")[:other])
+        .to eq(plural_text_original_other)
+      expect(I18n.t("notification.#{target_type_key}.#{plural_text_key}.text",
+        {article_title: article_title, notifier_name: notifier_name, count: 1}))
+        .to eq(plural_text_embedded_one)
+      expect(I18n.t("notification.#{target_type_key}.#{plural_text_key}.text",
+        {article_title: article_title, notifier_name: notifier_name, count: group_notification_count}))
+        .to eq(plural_text_embedded_other)
     end
   end
 
@@ -83,7 +102,7 @@ shared_examples_for :renderable do
           context "when the text has embedded parameters" do
             it "uses text with embedded parameters" do
               test_instance.key = params_text_key
-              expect(test_instance.text({notifier_name: notifier_name, article_title: article_title}))
+              expect(test_instance.text({article_title: article_title}))
                 .to eq(params_text_embedded)
             end
 

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -84,7 +84,7 @@ describe ActivityNotification::Mailer do
           notification.notifiable.extend(AdditionalMethods)
           ActivityNotification::Mailer.send_notification_email(notification).deliver_now
           expect(ActivityNotification::Mailer.deliveries.last.subject)
-            .to eq("New comment to your article")
+            .to eq("New comment on your article")
         end
       end
 

--- a/spec/rails_app/config/locales/activity_notification.en.yml
+++ b/spec/rails_app/config/locales/activity_notification.en.yml
@@ -6,14 +6,18 @@ en:
       article:
         create:
           text: 'Article has been created'
+        update:
+          text: 'Article %{article_title} has been updated'
         destroy:
           text: 'Some user removed an article!'
       comment:
         post:
-          text: "<p>%{notifier_name} posted comments to your article %{article_title}</p>"
+          text:
+            one: "<p>%{notifier_name} posted a comment on your article %{article_title}</p>"
+            other: "<p>%{notifier_name} posted %{count} comments on your article %{article_title}</p>"
         reply:
-          text: "<p>%{notifier_name} and %{group_member_count} people replied for your comments</p>"
-          mail_subject: 'New comment to your article'
+          text: "<p>%{notifier_name} and %{group_member_count} other people replied %{group_notification_count} times to your comment</p>"
+          mail_subject: 'New comment on your article'
     admin:
       article:
         post:


### PR DESCRIPTION
This allows for pluralization of grouped notifications such as:

- _foo_ posted a comment on your article _bar_
- _foo_ posted 2 comments on your article _bar_

There are no breaking changes as it falls back to the default existing interpolation if the plural i18n translation doesn't exist.