### PR TITLE
Remove duplicate scope (also defined in API)

### DIFF
--- a/lib/activity_notification/orm/active_record/notification.rb
+++ b/lib/activity_notification/orm/active_record/notification.rb
@@ -120,14 +120,6 @@ module ActivityNotification
         # @return [ActiveRecord_AssociationRelation<Notificaion>] Database query of filtered notifications
         scope :filtered_by_instance,              ->(notifiable) { where(notifiable: notifiable) }
 
-        # Selects filtered notifications by notifiable_type.
-        # @example Get filtered unopened notificatons of the @user for Comment notifiable class
-        #   @notifications = @user.notifications.unopened_only.filtered_by_type('Comment')
-        # @scope class
-        # @param [String] notifiable_type Notifiable type for filter
-        # @return [ActiveRecord_AssociationRelation<Notificaion>] Database query of filtered notifications
-        scope :filtered_by_type,                  ->(notifiable_type) { where(notifiable_type: notifiable_type) }
-
         # Selects filtered notifications by group instance.
         # @example Get filtered unopened notificatons of the @user for @article as group
         #   @notifications = @user.notifications.unopened_only.filtered_by_group(@article)


### PR DESCRIPTION
The `filtered_by_type` scope is defined both in the ActiveRecord ORM and the notification API (which is also included) so creates the duplicate scope warning:

> WARN -- : Creating scope :filtered_by_type. Overwriting existing method ActivityNotification::ORM::ActiveRecord::Notification.filtered_by_type.

Fixed: https://github.com/simukappu/activity_notification/issues/31