### PR TITLE
change the readme about the email templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ config.mailer_sender = ->(key){ key == 'inquiry.post' ? 'support@example.com' : 
 
 #### Email templates
 
-*activity_notification* will look for email template in the same way as notification views. For example, if you have a notification with *:key* set to *"notification.comment.reply"* and target_type *users*, the gem will look for a partial in *app/views/activity_notification/mailer/users/comment/_reply.html.(|erb|haml|slim|something_else)*.
+*activity_notification* will look for email template in a similar way as notification views, but the view file name is not start with an underscore. For example, if you have a notification with *:key* set to *"notification.comment.reply"* and target_type *users*, the gem will look for a partial in *app/views/activity_notification/mailer/users/comment/reply.html.(|erb|haml|slim|something_else)*.
 
 If this template is missing, the gem will look for a partial in *default* as the target type which means *activity_notification/mailer/default/_default.html.(|erb|haml|slim|something_else)*.
 


### PR DESCRIPTION
I suppose the way of activity_notification looking for email template is not exact as the readme file. The view file name is just the last word of the key split by the period, not started with an underscore. I come across the problem in my project, and trace the code, finally solve it by changing the view file name.