### PR TITLE
Configurable from, reply_to and message_id mailer headers

### DIFF
--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -102,6 +102,47 @@ describe ActivityNotification::Mailer do
         end
       end
 
+      context "with defined overriding_notification_email_from in notifiable model" do
+        it "sends with updated from" do
+          module AdditionalMethods
+            def overriding_notification_email_from(target, key)
+              'test05@example.com'
+            end
+          end
+          notification.notifiable.extend(AdditionalMethods)
+          ActivityNotification::Mailer.send_notification_email(notification).deliver_now
+          expect(ActivityNotification::Mailer.deliveries.last.from.first)
+            .to eq('test05@example.com')
+        end
+      end
+
+      context "with defined overriding_notification_email_reply_to in notifiable model" do
+        it "sends with updated reply_to" do
+          module AdditionalMethods
+            def overriding_notification_email_reply_to(target, key)
+              'test06@example.com'
+            end
+          end
+          notification.notifiable.extend(AdditionalMethods)
+          ActivityNotification::Mailer.send_notification_email(notification).deliver_now
+          expect(ActivityNotification::Mailer.deliveries.last.reply_to.first)
+            .to eq('test06@example.com')
+        end
+      end
+
+      context "with defined overriding_notification_email_message_id in notifiable model" do
+        it "sends with specific message id" do
+          module AdditionalMethods
+            def overriding_notification_email_message_id(target, key)
+              "https://www.example.com/test@example.com/"
+            end
+          end
+          notification.notifiable.extend(AdditionalMethods)
+          ActivityNotification::Mailer.send_notification_email(notification).deliver_now
+          expect(ActivityNotification::Mailer.deliveries.last.message_id)
+            .to eq("https://www.example.com/test@example.com/")
+        end
+      end
       context "when fallback option is :none and the template is missing" do
         it "raise ActionView::MissingTemplate" do
           expect { ActivityNotification::Mailer.send_notification_email(notification, fallback: :none).deliver_now }


### PR DESCRIPTION
I have a use case in my project that requires custom `Reply-To` & `Message-ID` headers on outgoing email notifications for certain notifiables (these values are parsed when a reply is received and allows users to reply to threads via email).

Currently I have a custom mailer and notification hooks for this that mail notifications when a reply is posted, but activity_notification could handle the notification completely if I could set these options myself.

I created this patch to work similarly to how overriding the email subject currently works, and perhaps it would be beneficial for others too if you think this is a useful feature that could be merged upstream. I'm looking forward to any comments you may have. Thanks!