### PR TITLE
Fix eager_load by autoloading VERSION

### DIFF
--- a/lib/activity_notification.rb
+++ b/lib/activity_notification.rb
@@ -16,6 +16,7 @@ module ActivityNotification
   autoload :Common
   autoload :Config
   autoload :Renderable
+  autoload :VERSION
   autoload :GEM_VERSION
 
   module Mailers


### PR DESCRIPTION
**Issue #, if available**:
#124 
### Summary
Fix `config.eager_load = true` crash by adding back `autoload VERSION` as it's used in [`apidocs_controller.rb`](https://github.com/simukappu/activity_notification/blob/master/app/controllers/activity_notification/apidocs_controller.rb#L9)
<!-- Provide a general description of the code changes in your pull request. 
Were there any bugs you had fixed? If so, mention them.
If these bugs have open GitHub issues, be sure to tag them here as well, to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.

Thank you for contributing to activity_notification! -->