### PR TITLE
add erroned spec

### DIFF
--- a/lib/activity_notification/orm/mongoid/subscription.rb
+++ b/lib/activity_notification/orm/mongoid/subscription.rb
@@ -28,7 +28,7 @@ module ActivityNotification
         field :optional_targets,          type: Hash,    default: {}
 
         validates  :target,               presence: true
-        validates  :key,                  presence: true, uniqueness: { scope: :target }
+        validates  :key,                  presence: true, uniqueness: { scope: [:target_type, :target_id] }
         validates_inclusion_of :subscribing,          in: [true, false]
         validates_inclusion_of :subscribing_to_email, in: [true, false]
         validate   :subscribing_to_email_cannot_be_true_when_subscribing_is_false

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -15,8 +15,8 @@ describe ActivityNotification::Subscription, type: :model do
     it "several targets can subscribe to the same key" do
       target = create(:confirmed_user)
       target2 = create(:confirmed_user)
-      subscription_1 = create(:subscription, target: target, key: 'key.4')
-      subscription_2 = create(:subscription, target: target2, key: 'key.4')
+      subscription_1 = create(:subscription, target: target, key: 'key.1')
+      subscription_2 = create(:subscription, target: target2, key: 'key.1')
       expect(subscription_2).to be_valid
     end
   end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -118,9 +118,15 @@ describe ActivityNotification::Subscription, type: :model do
         @subscription_3 = create(:subscription, target: @target, key: 'key.3', created_at: @subscription_1.created_at + 20.second)
         @subscription_4 = create(:subscription, target: @target, key: 'key.4', created_at: @subscription_1.created_at + 30.second)
       end
-
+      
       unless ActivityNotification.config.orm == :dynamoid
         context "using ORM other than dynamoid, you can directly call latest/earliest order method from class objects" do
+          
+          it "several targets can subscribe to the same key" do
+            @target2 = FactoryBot.create(:confirmed_user)
+            @subscription_5 = FactoryBot.create(:subscription, target: @target2, key: 'key.4', created_at: @subscription_1.created_at + 40.second)
+            expect(@subscription_5).to be_valid
+          end
 
           it "works with latest_order scope" do
             subscriptions = ActivityNotification::Subscription.latest_order

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -11,6 +11,14 @@ describe ActivityNotification::Subscription, type: :model do
       subscription = create(:subscription, target: target)
       expect(subscription.reload.target).to eq(target)
     end
+
+    it "several targets can subscribe to the same key" do
+      target = create(:confirmed_user)
+      target2 = create(:confirmed_user)
+      subscription_1 = create(:subscription, target: target, key: 'key.4')
+      subscription_2 = create(:subscription, target: target2, key: 'key.4')
+      expect(subscription_2).to be_valid
+    end
   end
 
   describe "with validation" do
@@ -118,15 +126,9 @@ describe ActivityNotification::Subscription, type: :model do
         @subscription_3 = create(:subscription, target: @target, key: 'key.3', created_at: @subscription_1.created_at + 20.second)
         @subscription_4 = create(:subscription, target: @target, key: 'key.4', created_at: @subscription_1.created_at + 30.second)
       end
-      
+
       unless ActivityNotification.config.orm == :dynamoid
         context "using ORM other than dynamoid, you can directly call latest/earliest order method from class objects" do
-          
-          it "several targets can subscribe to the same key" do
-            @target2 = FactoryBot.create(:confirmed_user)
-            @subscription_5 = FactoryBot.create(:subscription, target: @target2, key: 'key.4', created_at: @subscription_1.created_at + 40.second)
-            expect(@subscription_5).to be_valid
-          end
 
           it "works with latest_order scope" do
             subscriptions = ActivityNotification::Subscription.latest_order


### PR DESCRIPTION
Issue #126 :

### Summary
add spec to proof key validation error with mongoid
error is make only with commands like `AN_TEST_DB=mongodb AN_ORM=mongoid bundle exec rspec`