### PR TITLE
Fix ruby 2.7 deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
     - images
 
 rvm:
-#  - 2.7.0 # Need to respond to warnings for Ruby 3.0
+  - 2.7.1
   - 2.6.5
 #  - 2.5.7
 #  - 2.4.9

--- a/lib/activity_notification/orm/active_record.rb
+++ b/lib/activity_notification/orm/active_record.rb
@@ -6,7 +6,7 @@ module ActivityNotification
       # Defines has_many association with ActivityNotification models.
       # @return [ActiveRecord_AssociationRelation<Object>] Database query of associated model instances
       def has_many_records(name, options = {})
-        has_many name, options
+        has_many name, **options
       end
     end
   end

--- a/lib/activity_notification/orm/active_record/notification.rb
+++ b/lib/activity_notification/orm/active_record/notification.rb
@@ -23,14 +23,14 @@ module ActivityNotification
         # Belongs to group instance of this notification as polymorphic association.
         # @scope instance
         # @return [Object] Group instance of this notification
-        belongs_to :group,         { polymorphic: true }.merge(Rails::VERSION::MAJOR >= 5 ? { optional: true } : {})
+        belongs_to :group,         **{ polymorphic: true }.merge(Rails::VERSION::MAJOR >= 5 ? { optional: true } : {})
 
         # Belongs to group owner notification instance of this notification.
         # Only group member instance has :group_owner value.
         # Group owner instance has nil as :group_owner association.
         # @scope instance
         # @return [Notification] Group owner notification instance of this notification
-        belongs_to :group_owner, { class_name: "ActivityNotification::Notification" }.merge(Rails::VERSION::MAJOR >= 5 ? { optional: true } : {})
+        belongs_to :group_owner, **{ class_name: "ActivityNotification::Notification" }.merge(Rails::VERSION::MAJOR >= 5 ? { optional: true } : {})
 
         # Has many group member notification instances of this notification.
         # Only group owner instance has :group_members value.
@@ -42,7 +42,7 @@ module ActivityNotification
         # Belongs to :notifier instance of this notification.
         # @scope instance
         # @return [Object] Notifier instance of this notification
-        belongs_to :notifier,      { polymorphic: true }.merge(Rails::VERSION::MAJOR >= 5 ? { optional: true } : {})
+        belongs_to :notifier,      **{ polymorphic: true }.merge(Rails::VERSION::MAJOR >= 5 ? { optional: true } : {})
 
         # Serialize parameters Hash
         serialize  :parameters, Hash


### PR DESCRIPTION
**Issue #122**

### Summary

Fix the deprecation warnings for ruby 2.7
