### PR TITLE
adding nullify_notifiable as option to dependent_notifications

### DIFF
--- a/lib/activity_notification/models/concerns/notifiable.rb
+++ b/lib/activity_notification/models/concerns/notifiable.rb
@@ -465,6 +465,14 @@ module ActivityNotification
         end
       end
 
+      # Update the notifiable_type and notifiable_id from the target to nil
+      # This method is intended to be called before destroy this notifiable as dependent configuration.
+      # @api private
+      # @param [String]  target_type       Target type of generated notifications
+      def nullify_notifiable_on_notifications_with_dependency(target_type)
+        generated_notifications_as_notifiable_for(target_type).update_all(notifiable_id: nil, notifiable_type: nil)
+      end
+
       # Removes generated notifications from notification group to new group owner.
       # This method is intended to be called before destroy this notifiable as dependent configuration.
       # @api private


### PR DESCRIPTION
**Issue #, if available**:
https://github.com/simukappu/activity_notification/issues/140
### Summary
1. Adding a new option to available_dependent_notifications_options called nullify_notifiable.
2. Adding a new option to add_destroy_dependency for that key we defined before.
3. Defining into the Notifiable module the new function which will update all the generated_notifications_as_notifiable_for(target_type) to notifiable_type and id to nil.
