### PR TITLE
Fix hash syntax in swagger schemas

### DIFF
--- a/lib/activity_notification/models/concerns/swagger/notification_schema.rb
+++ b/lib/activity_notification/models/concerns/swagger/notification_schema.rb
@@ -90,7 +90,7 @@ module ActivityNotification
               type: :string
             }
             key :example, {
-              "test_default_param": "1"
+              test_default_param: "1"
             }
           end
           property :opened_at do
@@ -139,28 +139,28 @@ module ActivityNotification
                 key :type, :object
                 key :description, "Associated target model in your application"
                 key :example, {
-                  "id": 1,
-                  "email": "ichiro@example.com",
-                  "name": "Ichiro",
-                  "created_at": Time.current,
-                  "updated_at": Time.current,
-                  "provider": "email",
-                  "uid": "",
-                  "printable_type": "User",
-                  "printable_target_name": "Ichiro"
+                  id: 1,
+                  email: "ichiro@example.com",
+                  name: "Ichiro",
+                  created_at: Time.current,
+                  updated_at: Time.current,
+                  provider: "email",
+                  uid: "",
+                  printable_type: "User",
+                  printable_target_name: "Ichiro"
                 }
               end
               property :notifiable do
                 key :type, :object
                 key :description, "Associated notifiable model in your application"
                 key :example, {
-                  "id": 22,
-                  "user_id": 2,
-                  "article_id": 11,
-                  "body": "This is the first Stephen's comment to Ichiro's article.",
-                  "created_at": Time.current,
-                  "updated_at": Time.current,
-                  "printable_type": "Comment"
+                  id: 22,
+                  user_id: 2,
+                  article_id: 11,
+                  body: "This is the first Stephen's comment to Ichiro's article.",
+                  created_at: Time.current,
+                  updated_at: Time.current,
+                  printable_type: "Comment"
               }
               end
               property :group do
@@ -168,14 +168,14 @@ module ActivityNotification
                 key :description, "Associated group model in your application"
                 key :nullable, true
                 key :example, {
-                  "id": 11,
-                  "user_id": 4,
-                  "title": "Ichiro's great article",
-                  "body": "This is Ichiro's great article. Please read it!",
-                  "created_at": Time.current,
-                  "updated_at": Time.current,
-                  "printable_type": "Article",
-                  "printable_group_name": "article \"Ichiro's great article\""
+                  id: 11,
+                  user_id: 4,
+                  title: "Ichiro's great article",
+                  body: "This is Ichiro's great article. Please read it!",
+                  created_at: Time.current,
+                  updated_at: Time.current,
+                  printable_type: "Article",
+                  printable_group_name: "article \"Ichiro's great article\""
                 }
               end
               property :notifier do
@@ -183,15 +183,15 @@ module ActivityNotification
                 key :description, "Associated notifier model in your application"
                 key :nullable, true
                 key :example, {
-                  "id": 2,
-                  "email": "stephen@example.com",
-                  "name": "Stephen",
-                  "created_at": Time.current,
-                  "updated_at": Time.current,
-                  "provider": "email",
-                  "uid": "",
-                  "printable_type": "User",
-                  "printable_notifier_name": "Stephen"
+                  id: 2,
+                  email: "stephen@example.com",
+                  name: "Stephen",
+                  created_at: Time.current,
+                  updated_at: Time.current,
+                  provider: "email",
+                  uid: "",
+                  printable_type: "User",
+                  printable_notifier_name: "Stephen"
                 }
               end
               property :group_members do

--- a/lib/activity_notification/models/concerns/swagger/subscription_schema.rb
+++ b/lib/activity_notification/models/concerns/swagger/subscription_schema.rb
@@ -90,15 +90,15 @@ module ActivityNotification
                   }
                 }
                 key :example, {
-                  "action_cable_channel": {
-                    "subscribing": true,
-                    "subscribed_at": Time.current,
-                    "unsubscribed_at": nil
+                  action_cable_channel:  {
+                    subscribing:  true,
+                    subscribed_at:  Time.current,
+                    unsubscribed_at:  nil
                   },
-                  "slack": {
-                    "subscribing": false,
-                    "subscribed_at": nil,
-                    "unsubscribed_at": Time.current
+                  slack:  {
+                    subscribing:  false,
+                    subscribed_at:  nil,
+                    unsubscribed_at:  Time.current
                   }
                 }
               end
@@ -114,11 +114,11 @@ module ActivityNotification
                 key :type, :object
                 key :description, "Associated target model in your application"
                 key :example, {
-                  "id": 1,
-                  "email": "ichiro@example.com",
-                  "name": "Ichiro",
-                  "created_at": Time.current,
-                  "updated_at": Time.current
+                  id:  1,
+                  email:  "ichiro@example.com",
+                  name:  "Ichiro",
+                  created_at:  Time.current,
+                  updated_at:  Time.current
                 }
               end
             end
@@ -145,11 +145,11 @@ module ActivityNotification
                   }
                 }
                 key :example, {
-                  "action_cable_channel": {
-                    "subscribing": true
+                  action_cable_channel:  {
+                    subscribing:  true
                   },
-                  "slack": {
-                    "subscribing": false
+                  slack:  {
+                    subscribing:  false
                   }
                 }
               end


### PR DESCRIPTION
**Issue #146 

### Summary

The following hash syntax being used in `notification_schema.rb` and `subscription_schema.rb` schemas causes a syntax error on `ruby 2.1`

```
$ruby -e "h = {\"key\": \"value\"}; puts h"
-e:1: syntax error, unexpected ':', expecting =>
h = {"key": "value"}; puts h
           ^
-e:1: syntax error, unexpected '}', expecting end-of-input
h = {"key": "value"}; puts h
```

Using the following syntax we get the hash as expected with a symbol as the key: 
```
ruby -e "h = {key: \"value\"}; puts h"
{:key=>"value"}
```