### PR TITLE
Remove Ruby 2.7 deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
     - images
 
 rvm:
-#  - 2.7.0 # Need to respond to warnings for Ruby 3.0
+  - 2.7.1
   - 2.6.5
 #  - 2.5.7
 #  - 2.4.9

--- a/lib/activity_notification/common.rb
+++ b/lib/activity_notification/common.rb
@@ -16,7 +16,11 @@ module ActivityNotification
     when Symbol
       symbol_method = context.method(thing)
       if symbol_method.arity > 1
-        symbol_method.call(ActivityNotification.get_controller, *args)
+        if args.last.kind_of?(Hash)
+          symbol_method.call(ActivityNotification.get_controller, *args[0...-1], **args[-1])
+        else
+          symbol_method.call(ActivityNotification.get_controller, *args)
+        end
       elsif symbol_method.arity > 0
         symbol_method.call(ActivityNotification.get_controller)
       else
@@ -74,7 +78,11 @@ module ActivityNotification
       when Symbol
         symbol_method = method(thing)
         if symbol_method.arity > 0
-          symbol_method.call(*args)
+          if args.last.kind_of?(Hash)
+            symbol_method.call(*args[0...-1], **args[-1])
+          else
+            symbol_method.call(*args)
+          end
         else
           symbol_method.call
         end

--- a/lib/activity_notification/orm/active_record.rb
+++ b/lib/activity_notification/orm/active_record.rb
@@ -6,7 +6,7 @@ module ActivityNotification
       # Defines has_many association with ActivityNotification models.
       # @return [ActiveRecord_AssociationRelation<Object>] Database query of associated model instances
       def has_many_records(name, options = {})
-        has_many name, options
+        has_many name, **options
       end
     end
   end

--- a/lib/activity_notification/orm/active_record/notification.rb
+++ b/lib/activity_notification/orm/active_record/notification.rb
@@ -23,14 +23,14 @@ module ActivityNotification
         # Belongs to group instance of this notification as polymorphic association.
         # @scope instance
         # @return [Object] Group instance of this notification
-        belongs_to :group,         { polymorphic: true }.merge(Rails::VERSION::MAJOR >= 5 ? { optional: true } : {})
+        belongs_to :group,         **{ polymorphic: true }.merge(Rails::VERSION::MAJOR >= 5 ? { optional: true } : {})
 
         # Belongs to group owner notification instance of this notification.
         # Only group member instance has :group_owner value.
         # Group owner instance has nil as :group_owner association.
         # @scope instance
         # @return [Notification] Group owner notification instance of this notification
-        belongs_to :group_owner, { class_name: "ActivityNotification::Notification" }.merge(Rails::VERSION::MAJOR >= 5 ? { optional: true } : {})
+        belongs_to :group_owner, **{ class_name: "ActivityNotification::Notification" }.merge(Rails::VERSION::MAJOR >= 5 ? { optional: true } : {})
 
         # Has many group member notification instances of this notification.
         # Only group owner instance has :group_members value.
@@ -42,7 +42,7 @@ module ActivityNotification
         # Belongs to :notifier instance of this notification.
         # @scope instance
         # @return [Object] Notifier instance of this notification
-        belongs_to :notifier,      { polymorphic: true }.merge(Rails::VERSION::MAJOR >= 5 ? { optional: true } : {})
+        belongs_to :notifier,      **{ polymorphic: true }.merge(Rails::VERSION::MAJOR >= 5 ? { optional: true } : {})
 
         # Serialize parameters Hash
         serialize  :parameters, Hash

--- a/lib/activity_notification/renderable.rb
+++ b/lib/activity_notification/renderable.rb
@@ -29,8 +29,8 @@ module ActivityNotification
       )
 
       # Generate the :default fallback key without using pluralization key :count
-      default = I18n.t(k, attrs)
-      I18n.t(k, attrs.merge(count: group_notification_count, default: default))
+      default = I18n.t(k, **attrs)
+      I18n.t(k, **attrs.merge(count: group_notification_count, default: default))
     end
 
     # Renders notification from views.

--- a/spec/concerns/common_spec.rb
+++ b/spec/concerns/common_spec.rb
@@ -34,7 +34,7 @@ shared_examples_for :common do
           test_instance.extend(AdditionalMethods)
           expect(ActivityNotification.resolve_value(test_instance, :custom_method)).to eq(1)
         end
-  
+
         it "returns specified symbol with controller and additional arguments" do
           module AdditionalMethods
             def custom_method(controller, key)
@@ -45,6 +45,17 @@ shared_examples_for :common do
           expect(ActivityNotification.resolve_value(test_instance, :custom_method, 'test1.key')).to eq(1)
           expect(ActivityNotification.resolve_value(test_instance, :custom_method, 'test2.key')).to eq(0)
         end
+
+        it "returns specified symbol with controller and additional arguments including hash as last argument" do
+           module AdditionalMethods
+             def custom_method(controller, key, options:)
+               controller == 'StubController' and key == 'test1.key' ? 1 : 0
+             end
+           end
+           test_instance.extend(AdditionalMethods)
+           expect(ActivityNotification.resolve_value(test_instance, :custom_method, 'test1.key', options: 1)).to eq(1)
+           expect(ActivityNotification.resolve_value(test_instance, :custom_method, 'test2.key', options: 1)).to eq(0)
+         end
       end
 
       context "with Proc" do
@@ -62,7 +73,7 @@ shared_examples_for :common do
           test_proc = ->(controller, model){ controller == 'StubController' and model == test_instance ? 1 : 0 }
           expect(ActivityNotification.resolve_value(test_instance, test_proc)).to eq(1)
         end
-  
+
         it "returns specified lambda with controller, context(model) and additional arguments" do
           test_proc = ->(controller, model, key){ controller == 'StubController' and model == test_instance and key == 'test1.key' ? 1 : 0 }
           expect(ActivityNotification.resolve_value(test_instance, test_proc, 'test1.key')).to eq(1)
@@ -117,6 +128,17 @@ shared_examples_for :common do
           test_instance.extend(AdditionalMethods)
           expect(test_instance.resolve_value(:custom_method, 'test1.key')).to eq(1)
           expect(test_instance.resolve_value(:custom_method, 'test2.key')).to eq(0)
+        end
+
+        it "returns specified symbol with additional arguments including hash as last argument" do
+          module AdditionalMethods
+            def custom_method(key, options:)
+              key == 'test1.key' ? 1 : 0
+            end
+          end
+          test_instance.extend(AdditionalMethods)
+          expect(test_instance.resolve_value(:custom_method, 'test1.key', options: 1)).to eq(1)
+          expect(test_instance.resolve_value(:custom_method, 'test2.key', options: 1)).to eq(0)
         end
       end
 

--- a/spec/concerns/renderable_spec.rb
+++ b/spec/concerns/renderable_spec.rb
@@ -32,7 +32,7 @@ shared_examples_for :renderable do
       expect(I18n.t("notification.#{target_type_key}.#{params_text_key}.text"))
         .to eq(params_text_original)
       expect(I18n.t("notification.#{target_type_key}.#{params_text_key}.text",
-        {article_title: article_title}))
+        article_title: article_title))
         .to eq(params_text_embedded)
     end
 
@@ -40,7 +40,7 @@ shared_examples_for :renderable do
       expect(I18n.t("notification.#{target_type_key}.#{group_text_key}.text"))
         .to eq(group_text_original)
       expect(I18n.t("notification.#{target_type_key}.#{group_text_key}.text",
-        {notifier_name: notifier_name, group_member_count: group_member_count, group_notification_count: group_notification_count}))
+        **{ notifier_name: notifier_name, group_member_count: group_member_count, group_notification_count: group_notification_count }))
         .to eq(group_text_embedded)
     end
 
@@ -50,10 +50,10 @@ shared_examples_for :renderable do
       expect(I18n.t("notification.#{target_type_key}.#{plural_text_key}.text")[:other])
         .to eq(plural_text_original_other)
       expect(I18n.t("notification.#{target_type_key}.#{plural_text_key}.text",
-        {article_title: article_title, notifier_name: notifier_name, count: 1}))
+        **{ article_title: article_title, notifier_name: notifier_name, count: 1 }))
         .to eq(plural_text_embedded_one)
       expect(I18n.t("notification.#{target_type_key}.#{plural_text_key}.text",
-        {article_title: article_title, notifier_name: notifier_name, count: group_notification_count}))
+        **{ article_title: article_title, notifier_name: notifier_name, count: group_notification_count }))
         .to eq(plural_text_embedded_other)
     end
   end

--- a/spec/controllers/controller_spec_utility.rb
+++ b/spec/controllers/controller_spec_utility.rb
@@ -76,15 +76,15 @@ module ActivityNotification
         def api_path
           "/#{root_path}/#{target_type}/#{test_target.id}"
         end
-  
+
         def schema_path
-          Rails.root.join('..', 'openapi.json') 
+          Rails.root.join('..', 'openapi.json')
         end
-  
+
         def write_schema_file(schema_json)
           File.open(schema_path, "w") { |file| file.write(schema_json) }
         end
-  
+
         def read_schema_file
           JSON.parse(File.read(schema_path))
         end
@@ -97,7 +97,7 @@ module ActivityNotification
           if Rails::VERSION::MAJOR <= 4
             get path, options[:params], options[:headers]
           else
-            get path, options
+            get path, **options
           end
         end
 
@@ -105,7 +105,7 @@ module ActivityNotification
           if Rails::VERSION::MAJOR <= 4
             post path, options[:params], options[:headers]
           else
-            post path, options
+            post path, **options
           end
         end
 
@@ -113,7 +113,7 @@ module ActivityNotification
           if Rails::VERSION::MAJOR <= 4
             put path, options[:params], options[:headers]
           else
-            put path, options
+            put path, **options
           end
         end
 
@@ -121,7 +121,7 @@ module ActivityNotification
           if Rails::VERSION::MAJOR <= 4
             delete path, options[:params], options[:headers]
           else
-            delete path, options
+            delete path, **options
           end
         end
 


### PR DESCRIPTION
Resolve #122 

**Summary**

This PR fixes all deprecation warnings appearing in specs for ruby 2.7. 

(For easier work I also pulled @szechyjs commit into this PR, we should probably merge https://github.com/simukappu/activity_notification/pull/137 first and then I will rebase this PR. @simukappu is it okay with you?)