### PR TITLE
Don’t silence optional target exceptions

### DIFF
--- a/lib/activity_notification/apis/notification_api.rb
+++ b/lib/activity_notification/apis/notification_api.rb
@@ -542,7 +542,7 @@ module ActivityNotification
             [optional_target_name, true]
           rescue => e
             Rails.logger.error(e)
-            [optional_target_name, e]
+            raise e
           end
         else
           [optional_target_name, false]

--- a/spec/concerns/apis/notification_api_spec.rb
+++ b/spec/concerns/apis/notification_api_spec.rb
@@ -136,9 +136,17 @@ shared_examples_for :notification_api do
           Comment._optional_targets[:users] = @current_optional_target
         end
 
-        it "generates notifications even if some optional targets raise error" do
-          notifications = described_class.notify(:users, @comment_2)
-          expect(notifications.size).to eq(2)  
+        it "raises an capturable exception" do
+          expect { described_class.notify(:users, @comment_2) }.to raise_error(RuntimeError)
+        end
+
+        it "allows an exception to be captured to continue" do
+          begin
+            notifications = described_class.notify(:users, @comment_2)
+            expect(notifications.size).to eq(2)
+          rescue => e
+            next
+          end
         end
       end
     end


### PR DESCRIPTION
**Issue #155**

### Summary
Don't silence OptionalTarget exceptions because when using the Notification#notify API there's no way to access the errors and they are completely lost (other than reaching into Rails.logger.error).

Better is to allow the user to rescue their own code so they can perform the necessary result. [If they just want to silently skip](https://github.com/simukappu/activity_notification/issues/103), then `next` is their friend.