### PR TITLE
Remove redundant double splat

### DIFF
--- a/lib/activity_notification/orm/active_record/notification.rb
+++ b/lib/activity_notification/orm/active_record/notification.rb
@@ -23,14 +23,14 @@ module ActivityNotification
         # Belongs to group instance of this notification as polymorphic association.
         # @scope instance
         # @return [Object] Group instance of this notification
-        belongs_to :group,         **{ polymorphic: true, optional: true }
+        belongs_to :group,         polymorphic: true, optional: true
 
         # Belongs to group owner notification instance of this notification.
         # Only group member instance has :group_owner value.
         # Group owner instance has nil as :group_owner association.
         # @scope instance
         # @return [Notification] Group owner notification instance of this notification
-        belongs_to :group_owner, **{ class_name: "ActivityNotification::Notification", optional: true }
+        belongs_to :group_owner,   class_name: "ActivityNotification::Notification", optional: true
 
         # Has many group member notification instances of this notification.
         # Only group owner instance has :group_members value.
@@ -42,7 +42,7 @@ module ActivityNotification
         # Belongs to :notifier instance of this notification.
         # @scope instance
         # @return [Object] Notifier instance of this notification
-        belongs_to :notifier,      **{ polymorphic: true, optional: true }
+        belongs_to :notifier,      polymorphic: true, optional: true
 
         # Serialize parameters Hash
         serialize  :parameters, Hash


### PR DESCRIPTION
Just clean up the code.

ref:

* Add `{ optional: true }` when Rails 5
  - 4459cabb2005d15849b5c1de01b86329f58cad2a
* Add double splat
  - f989d7590097b6e52783e4bc822fa6ddd94de347
* Drop Rails 4.2 Support
  - 181c259eded50752ab270e1c421b82472497c74b