### PR TITLE
Configure default subscriptions for emails and optional targets

### DIFF
--- a/app/controllers/activity_notification/subscriptions_controller.rb
+++ b/app/controllers/activity_notification/subscriptions_controller.rb
@@ -91,8 +91,8 @@ module ActivityNotification
     #   @option params [String] :filtered_by_key         (nil)     Key of the subscription for filter
     #   @return [Response] JavaScript view for ajax request or redirects to back as default
     def subscribe
-      @subscription.subscribe(with_email_subscription: params[:with_email_subscription].to_s.to_boolean(true),
-                              with_optional_targets:   params[:with_optional_targets].to_s.to_boolean(true))
+      @subscription.subscribe(with_email_subscription: params[:with_email_subscription].to_s.to_boolean(ActivityNotification.config.subscribe_to_email_as_default),
+                              with_optional_targets:   params[:with_optional_targets].to_s.to_boolean(ActivityNotification.config.subscribe_to_optional_targets_as_default))
       return_back_or_ajax
     end
 

--- a/app/views/activity_notification/subscriptions/default/_form.html.erb
+++ b/app/views/activity_notification/subscriptions/default/_form.html.erb
@@ -37,7 +37,7 @@
         <div class="field">
           <div class="ui checkbox">
             <label>
-              <%= f.check_box :subscribing_to_email, { checked: ActivityNotification.config.subscribe_as_default }, 'true', 'false' %>
+              <%= f.check_box :subscribing_to_email, { checked: ActivityNotification.config.subscribe_to_email_as_default }, 'true', 'false' %>
               <div class="slider"></div>
             </label>
           </div>

--- a/app/views/activity_notification/subscriptions/default/_notification_keys.html.erb
+++ b/app/views/activity_notification/subscriptions/default/_notification_keys.html.erb
@@ -38,7 +38,7 @@
             <div class="field">
               <div class="ui checkbox">
                 <label>
-                  <%= f.check_box :subscribing_to_email, { checked: ActivityNotification.config.subscribe_as_default }, 'true', 'false' %>
+                  <%= f.check_box :subscribing_to_email, { checked: ActivityNotification.config.subscribe_to_email_as_default }, 'true', 'false' %>
                   <div class="slider"></div>
                 </label>
               </div>
@@ -56,7 +56,7 @@
                 <div class="ui checkbox">
                   <label>
                     <%= hidden_field_tag "subscription[optional_targets][#{ActivityNotification::Subscription.to_optional_target_key(optional_target_name)}]", 'false', id: "#{key}_subscription_optional_targets_subscribing_to_#{ActivityNotification::Subscription.to_optional_target_key(optional_target_name)}_hidden" %>
-                    <%= check_box_tag "subscription[optional_targets][#{ActivityNotification::Subscription.to_optional_target_key(optional_target_name)}]", 'true', ActivityNotification.config.subscribe_as_default, id: "#{key}_subscription_optional_targets_subscribing_to_#{ActivityNotification::Subscription.to_optional_target_key(optional_target_name)}_check_box" %>
+                    <%= check_box_tag "subscription[optional_targets][#{ActivityNotification::Subscription.to_optional_target_key(optional_target_name)}]", 'true', ActivityNotification.config.subscribe_to_optional_targets_as_default, id: "#{key}_subscription_optional_targets_subscribing_to_#{ActivityNotification::Subscription.to_optional_target_key(optional_target_name)}_check_box" %>
                     <div class="slider"></div>
                   </label>
                 </div>

--- a/app/views/activity_notification/subscriptions/default/_subscription.html.erb
+++ b/app/views/activity_notification/subscriptions/default/_subscription.html.erb
@@ -29,7 +29,7 @@
               <div class="slider"></div>
             <% end %>
           <% else %>
-            <%= link_to subscribe_path_for(subscription, option_params.merge(with_email_subscription: false, with_optional_targets: false)), onclick: '$(this).find("input").prop("checked", true);$(this).parent().parent().parent().next().slideDown();$(this).parent().parent().parent().next().next().slideDown();', method: :put, remote: true do %>
+            <%= link_to subscribe_path_for(subscription, option_params), onclick: '$(this).find("input").prop("checked", true);$(this).parent().parent().parent().next().slideDown();$(this).parent().parent().parent().next().next().slideDown();', method: :put, remote: true do %>
               <%= check_box :subscribing, "", { checked: false }, 'true', 'false' %>
               <div class="slider"></div>
             <% end %>

--- a/app/views/activity_notification/subscriptions/default/_subscription.html.erb
+++ b/app/views/activity_notification/subscriptions/default/_subscription.html.erb
@@ -24,7 +24,7 @@
           <% end %>
         <% else %>
           <% if ActivityNotification.config.subscribe_as_default %>
-            <%= link_to subscribe_path_for(subscription, option_params.merge(with_email_subscription: ActivityNotification.config.subscribe_to_email_as_default, with_optional_targets: ActivityNotification.config.subscribe_to_optional_targets_as_default)), onclick: "$(this).find(\"input\").prop(\"checked\", true);$(this).parent().parent().parent().next().slideDown();$(this).parent().parent().parent().next().find(\"input\").prop(\"checked\", #{ActivityNotification.config.subscribe_to_email_as_default.to_s});$(this).parent().parent().parent().next().next().slideDown();$(this).parent().parent().parent().next().next().find(\"input\").prop(\"checked\", #{ActivityNotification.config.subscribe_to_optional_targets_as_default});", method: :put, remote: true do %>
+            <%= link_to subscribe_path_for(subscription, option_params), onclick: "$(this).find(\"input\").prop(\"checked\", true);$(this).parent().parent().parent().next().slideDown();$(this).parent().parent().parent().next().find(\"input\").prop(\"checked\", #{ActivityNotification.config.subscribe_to_email_as_default.to_s});$(this).parent().parent().parent().next().next().slideDown();$(this).parent().parent().parent().next().next().find(\"input\").prop(\"checked\", #{ActivityNotification.config.subscribe_to_optional_targets_as_default});", method: :put, remote: true do %>
               <%= check_box :subscribing, "", { checked: false }, 'true', 'false' %>
               <div class="slider"></div>
             <% end %>

--- a/app/views/activity_notification/subscriptions/default/_subscription.html.erb
+++ b/app/views/activity_notification/subscriptions/default/_subscription.html.erb
@@ -24,12 +24,12 @@
           <% end %>
         <% else %>
           <% if ActivityNotification.config.subscribe_as_default %>
-            <%= link_to subscribe_path_for(subscription, option_params), onclick: '$(this).find("input").prop("checked", true);$(this).parent().parent().parent().next().slideDown();$(this).parent().parent().parent().next().find("input").prop("checked", true);$(this).parent().parent().parent().next().next().slideDown();$(this).parent().parent().parent().next().next().find("input").prop("checked", true);', method: :put, remote: true do %>
+            <%= link_to subscribe_path_for(subscription, option_params.merge(with_email_subscription: ActivityNotification.config.subscribe_to_email_as_default, with_optional_targets: ActivityNotification.config.subscribe_to_optional_targets_as_default)), onclick: "$(this).find(\"input\").prop(\"checked\", true);$(this).parent().parent().parent().next().slideDown();$(this).parent().parent().parent().next().find(\"input\").prop(\"checked\", #{ActivityNotification.config.subscribe_to_email_as_default.to_s});$(this).parent().parent().parent().next().next().slideDown();$(this).parent().parent().parent().next().next().find(\"input\").prop(\"checked\", #{ActivityNotification.config.subscribe_to_optional_targets_as_default});", method: :put, remote: true do %>
               <%= check_box :subscribing, "", { checked: false }, 'true', 'false' %>
               <div class="slider"></div>
             <% end %>
           <% else %>
-            <%= link_to subscribe_path_for(subscription, option_params.merge(with_email_subscription: false)), onclick: '$(this).find("input").prop("checked", true);$(this).parent().parent().parent().next().slideDown();$(this).parent().parent().parent().next().next().slideDown();', method: :put, remote: true do %>
+            <%= link_to subscribe_path_for(subscription, option_params.merge(with_email_subscription: false, with_optional_targets: false)), onclick: '$(this).find("input").prop("checked", true);$(this).parent().parent().parent().next().slideDown();$(this).parent().parent().parent().next().next().slideDown();', method: :put, remote: true do %>
               <%= check_box :subscribing, "", { checked: false }, 'true', 'false' %>
               <div class="slider"></div>
             <% end %>

--- a/app/views/activity_notification/subscriptions/default/index.html.erb
+++ b/app/views/activity_notification/subscriptions/default/index.html.erb
@@ -189,9 +189,9 @@
       $thisFieldWrapper = $(this).parent().parent().parent().parent();
       if ($(this).prop('checked')) {
         $thisFieldWrapper.next().slideDown();
-        $thisFieldWrapper.next().find("input[type='checkbox']").prop("checked", <%= ActivityNotification.config.subscribe_as_default %>);
+        $thisFieldWrapper.next().find("input[type='checkbox']").prop("checked", <%= ActivityNotification.config.subscribe_to_email_as_default %>);
         $thisFieldWrapper.next().next().slideDown();
-        $thisFieldWrapper.next().next().find("input[type='checkbox']").prop("checked", <%= ActivityNotification.config.subscribe_as_default %>);
+        $thisFieldWrapper.next().next().find("input[type='checkbox']").prop("checked", <%= ActivityNotification.config.subscribe_to_optional_targets_as_default %>);
       } else {
         $thisFieldWrapper.next().slideUp();
         $thisFieldWrapper.next().next().slideUp();

--- a/app/views/activity_notification/subscriptions/default/show.html.erb
+++ b/app/views/activity_notification/subscriptions/default/show.html.erb
@@ -165,9 +165,9 @@
       $thisFieldWrapper = $(this).parent().parent().parent().parent();
       if ($(this).prop('checked')) {
         $thisFieldWrapper.next().slideDown();
-        $thisFieldWrapper.next().find("input[type='checkbox']").prop("checked", <%= ActivityNotification.config.subscribe_as_default %>);
+        $thisFieldWrapper.next().find("input[type='checkbox']").prop("checked", <%= ActivityNotification.config.subscribe_to_email_as_default %>);
         $thisFieldWrapper.next().next().slideDown();
-        $thisFieldWrapper.next().next().find("input[type='checkbox']").prop("checked", <%= ActivityNotification.config.subscribe_as_default %>);
+        $thisFieldWrapper.next().next().find("input[type='checkbox']").prop("checked", <%= ActivityNotification.config.subscribe_to_optional_targets_as_default %>);
       } else {
         $thisFieldWrapper.next().slideUp();
         $thisFieldWrapper.next().next().slideUp();

--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -308,6 +308,8 @@ Subscriptions are managed by instances of **ActivityNotification::Subscription**
 *true* means the target will receive the notification email with this key including batch notification email with this *batch_key*.
 *false* means the target will not receive these notification email.
 
+##### Subscription defaults
+
 As default, all target subscribes to notification and notification email when subscription record does not exist in your database.
 You can change this **subscribe_as_default** parameter in initializer *activity_notification.rb*.
 
@@ -316,6 +318,20 @@ config.subscribe_as_default = false
 ```
 
 Then, all target does not subscribe to notification and notification email and will not receive any notifications as default.
+
+As default, email and optional target subscriptions will use the same default subscription value as defined in **subscribe_as_default**.
+You can disable them by providing **subscribe_to_email_as_default** or **subscribe_to_optional_targets_as_default** parameter(s) in initializer *activity_notification.rb*.
+
+```ruby
+# Enable subscribe as default, but disable it for emails
+config.subscribe_as_default = true
+config.subscribe_to_email_as_default = false
+config.subscribe_to_optional_targets_as_default = true
+```
+
+However if **subscribe_as_default** is not enabled, **subscribe_to_email_as_default** and **subscribe_to_optional_targets_as_default** won't change anything.
+
+##### Creating and updating subscriptions
 
 You can create subscription record from subscription API in your target model like this:
 
@@ -574,7 +590,7 @@ To sign in and get *access-token* from Devise Token Auth, call *sign_in* API whi
 ```console
 $ curl -X POST -H "Content-Type: application/json" -D - -d '{"email": "ichiro@example.com","password": "changeit"}' https://activity-notification-example.herokuapp.com/api/v2/auth/sign_in
 
- 
+
 HTTP/1.1 200 OK
 ...
 Content-Type: application/json; charset=utf-8

--- a/lib/activity_notification/apis/subscription_api.rb
+++ b/lib/activity_notification/apis/subscription_api.rb
@@ -127,8 +127,8 @@ module ActivityNotification
     # @return [Boolean] If successfully updated subscription instance
     def subscribe(options = {})
       subscribed_at = options[:subscribed_at] || Time.current
-      with_email_subscription = options.has_key?(:with_email_subscription) ? options[:with_email_subscription] : true
-      with_optional_targets   = options.has_key?(:with_optional_targets) ? options[:with_optional_targets] : true
+      with_email_subscription = options.has_key?(:with_email_subscription) ? options[:with_email_subscription] : ActivityNotification.config.subscribe_to_email_as_default
+      with_optional_targets   = options.has_key?(:with_optional_targets) ? options[:with_optional_targets] : ActivityNotification.config.subscribe_to_optional_targets_as_default
       new_attributes = { subscribing: true, subscribed_at: subscribed_at, optional_targets: optional_targets }
       new_attributes = new_attributes.merge(subscribing_to_email: true, subscribed_to_email_at: subscribed_at) if with_email_subscription
       if with_optional_targets

--- a/lib/activity_notification/apis/subscription_api.rb
+++ b/lib/activity_notification/apis/subscription_api.rb
@@ -21,7 +21,7 @@ module ActivityNotification
         #   @subscriptions = @user.subscriptions.filtered_by_options({ custom_filter: ["created_at >= ?", time.hour.ago] })
         # @scope class
         # @param [Hash] options Options for filter
-        # @option options [String]     :filtered_by_key        (nil) Key of the subscription for filter 
+        # @option options [String]     :filtered_by_key        (nil) Key of the subscription for filter
         # @option options [Array|Hash] :custom_filter          (nil) Custom subscription filter (e.g. ["created_at >= ?", time.hour.ago] or ['created_at.gt': time.hour.ago])
         # @return [ActiveRecord_AssociationRelation<Subscription>, Mongoid::Criteria<Notificaion>] Database query of filtered subscriptions
         scope :filtered_by_options, ->(options = {}) {
@@ -184,7 +184,7 @@ module ActivityNotification
     # @param [Symbol]  optional_target_name Symbol class name of the optional target implementation (e.g. :amazon_sns, :slack)
     # @param [Boolean] subscribe_as_default Default subscription value to use when the subscription record does not configured
     # @return [Boolean] If the target subscribes to the specified optional target
-    def subscribing_to_optional_target?(optional_target_name, subscribe_as_default = ActivityNotification.config.subscribe_as_default)
+    def subscribing_to_optional_target?(optional_target_name, subscribe_as_default = ActivityNotification.config.subscribe_to_optional_targets_as_default)
       optional_target_key = Subscription.to_optional_target_key(optional_target_name)
       subscribe_as_default ?
         !optional_targets.has_key?(optional_target_key) || optional_targets[optional_target_key] :

--- a/lib/activity_notification/config.rb
+++ b/lib/activity_notification/config.rb
@@ -61,6 +61,18 @@ module ActivityNotification
     #   @return [Boolean] Default subscription value to use when the subscription record does not configured.
     attr_accessor :subscribe_as_default
 
+    # @overload subscribe_to_email_as_default=(value)
+    #   Sets default email subscription value to use when the subscription record does not configured
+    #   @param [Boolean] subscribe_to_email_as_default The new subscribe_to_email_as_default
+    #   @return [Boolean] Default email subscription value to use when the subscription record does not configured.
+    attr_writer :subscribe_to_email_as_default
+
+    # @overload subscribe_to_optional_targets_as_default=(value)
+    #   Sets default optional target subscription value to use when the subscription record does not configured
+    #   @param [Boolean] subscribe_to_optional_targets_as_default The new subscribe_to_optional_targets_as_default
+    #   @return [Boolean] Default optional target subscription value to use when the subscription record does not configured.
+    attr_writer :subscribe_to_optional_targets_as_default
+
     # @overload mailer_sender
     #   Returns email address as sender of notification email
     #   @return [String] Email address as sender of notification email.
@@ -205,29 +217,31 @@ module ActivityNotification
     # These configuration can be overridden in initializer.
     # @return [Config] A new instance of Config
     def initialize
-      @enabled                         = true
-      @orm                             = :active_record
-      @notification_table_name         = 'notifications'
-      @subscription_table_name         = 'subscriptions'
-      @email_enabled                   = false
-      @subscription_enabled            = false
-      @subscribe_as_default            = true
-      @mailer_sender                   = nil
-      @mailer                          = 'ActivityNotification::Mailer'
-      @parent_mailer                   = 'ActionMailer::Base'
-      @parent_job                      = 'ActiveJob::Base'
-      @parent_controller               = 'ApplicationController'
-      @parent_channel                  = 'ActionCable::Channel::Base'
-      @mailer_templates_dir            = 'activity_notification/mailer'
-      @opened_index_limit              = 10
-      @active_job_queue                = :activity_notification
-      @composite_key_delimiter         = '#'
-      @store_with_associated_records   = false
-      @action_cable_enabled            = false
-      @action_cable_api_enabled        = false
-      @action_cable_with_devise        = false
-      @notification_channel_prefix     = 'activity_notification_channel'
-      @notification_api_channel_prefix = 'activity_notification_api_channel'
+      @enabled                                  = true
+      @orm                                      = :active_record
+      @notification_table_name                  = 'notifications'
+      @subscription_table_name                  = 'subscriptions'
+      @email_enabled                            = false
+      @subscription_enabled                     = false
+      @subscribe_as_default                     = true
+      @subscribe_to_email_as_default            = nil
+      @subscribe_to_optional_targets_as_default = nil
+      @mailer_sender                            = nil
+      @mailer                                   = 'ActivityNotification::Mailer'
+      @parent_mailer                            = 'ActionMailer::Base'
+      @parent_job                               = 'ActiveJob::Base'
+      @parent_controller                        = 'ApplicationController'
+      @parent_channel                           = 'ActionCable::Channel::Base'
+      @mailer_templates_dir                     = 'activity_notification/mailer'
+      @opened_index_limit                       = 10
+      @active_job_queue                         = :activity_notification
+      @composite_key_delimiter                  = '#'
+      @store_with_associated_records            = false
+      @action_cable_enabled                     = false
+      @action_cable_api_enabled                 = false
+      @action_cable_with_devise                 = false
+      @notification_channel_prefix              = 'activity_notification_channel'
+      @notification_api_channel_prefix          = 'activity_notification_api_channel'
     end
 
     # Sets ORM name for ActivityNotification (:active_record, :mongoid or :dynamodb)
@@ -244,6 +258,22 @@ module ActivityNotification
     def store_with_associated_records=(store_with_associated_records)
       if store_with_associated_records && [:mongoid, :dynamoid].exclude?(@orm) then raise ActivityNotification::ConfigError, "config.store_with_associated_records can be set true only when you use mongoid or dynamoid ORM." end
       @store_with_associated_records = store_with_associated_records
+    end
+
+    # Returns default email subscription value to use when the subscription record does not configured
+    # @return [Boolean] Default email subscription value to use when the subscription record does not configured.
+    def subscribe_to_email_as_default
+      return false unless @subscribe_as_default
+
+      @subscribe_to_email_as_default.nil? ? @subscribe_as_default : @subscribe_to_email_as_default
+    end
+
+    # Returns default optional target subscription value to use when the subscription record does not configured
+    # @return [Boolean] Default optinal target subscription value to use when the subscription record does not configured.
+    def subscribe_to_optional_targets_as_default
+      return false unless @subscribe_as_default
+
+      @subscribe_to_optional_targets_as_default.nil? ? @subscribe_as_default : @subscribe_to_optional_targets_as_default
     end
   end
 end

--- a/lib/activity_notification/models/concerns/subscriber.rb
+++ b/lib/activity_notification/models/concerns/subscriber.rb
@@ -62,6 +62,8 @@ module ActivityNotification
       created_at = Time.current
       if subscription_params[:subscribing] == false && subscription_params[:subscribing_to_email].nil?
         subscription_params[:subscribing_to_email] = subscription_params[:subscribing]
+      elsif subscription_params[:subscribing_to_email].nil?
+        subscription_params[:subscribing_to_email] = ActivityNotification.config.subscribe_to_email_as_default
       end
       subscription = Subscription.new(subscription_params)
       subscription.assign_attributes(target: self)

--- a/lib/activity_notification/models/concerns/subscriber.rb
+++ b/lib/activity_notification/models/concerns/subscriber.rb
@@ -61,7 +61,7 @@ module ActivityNotification
     def build_subscription(subscription_params = {})
       created_at = Time.current
       if subscription_params[:subscribing] == false && subscription_params[:subscribing_to_email].nil?
-        subscription_params[:subscribing_to_email] = subscription_params[:subscribing] 
+        subscription_params[:subscribing_to_email] = subscription_params[:subscribing]
       end
       subscription = Subscription.new(subscription_params)
       subscription.assign_attributes(target: self)
@@ -157,7 +157,7 @@ module ActivityNotification
       # @param [String]  key                  Key of the notification
       # @param [Boolean] subscribe_as_default Default subscription value to use when the subscription record does not configured
       # @return [Boolean] If the target subscribes to the notification
-      def _subscribes_to_notification_email?(key, subscribe_as_default = ActivityNotification.config.subscribe_as_default)
+      def _subscribes_to_notification_email?(key, subscribe_as_default = ActivityNotification.config.subscribe_to_email_as_default)
         evaluate_subscription(subscriptions.where(key: key).first, :subscribing_to_email?, subscribe_as_default)
       end
       alias_method :_subscribes_to_email?, :_subscribes_to_notification_email?
@@ -170,7 +170,7 @@ module ActivityNotification
       # @param [String, Symbol] optional_target_name Class name of the optional target implementation (e.g. :amazon_sns, :slack)
       # @param [Boolean]        subscribe_as_default Default subscription value to use when the subscription record does not configured
       # @return [Boolean] If the target subscribes to the specified optional target
-      def _subscribes_to_optional_target?(key, optional_target_name, subscribe_as_default = ActivityNotification.config.subscribe_as_default)
+      def _subscribes_to_optional_target?(key, optional_target_name, subscribe_as_default = ActivityNotification.config.subscribe_to_optional_targets_as_default)
         _subscribes_to_notification?(key, subscribe_as_default) &&
           evaluate_subscription(subscriptions.where(key: key).first, :subscribing_to_optional_target?, subscribe_as_default, optional_target_name, subscribe_as_default)
       end

--- a/lib/activity_notification/models/concerns/target.rb
+++ b/lib/activity_notification/models/concerns/target.rb
@@ -541,7 +541,7 @@ module ActivityNotification
     # @param [String]  key                  Key of the notification
     # @param [Boolean] subscribe_as_default Default subscription value to use when the subscription record does not configured
     # @return [Boolean] If the target subscribes the notification email or the subscription management is not allowed for the target
-    def subscribes_to_notification_email?(key, subscribe_as_default = ActivityNotification.config.subscribe_as_default)
+    def subscribes_to_notification_email?(key, subscribe_as_default = ActivityNotification.config.subscribe_to_email_as_default)
       !subscription_allowed?(key) || _subscribes_to_notification_email?(key, subscribe_as_default)
     end
     alias_method :subscribes_to_email?, :subscribes_to_notification_email?
@@ -553,7 +553,7 @@ module ActivityNotification
     # @param [String, Symbol] optional_target_name Class name of the optional target implementation (e.g. :amazon_sns, :slack)
     # @param [Boolean]        subscribe_as_default Default subscription value to use when the subscription record does not configured
     # @return [Boolean] If the target subscribes the notification email or the subscription management is not allowed for the target
-    def subscribes_to_optional_target?(key, optional_target_name, subscribe_as_default = ActivityNotification.config.subscribe_as_default)
+    def subscribes_to_optional_target?(key, optional_target_name, subscribe_as_default = ActivityNotification.config.subscribe_to_optional_targets_as_default)
       !subscription_allowed?(key) || _subscribes_to_optional_target?(key, optional_target_name, subscribe_as_default)
     end
 

--- a/lib/activity_notification/orm/dynamoid/subscription.rb
+++ b/lib/activity_notification/orm/dynamoid/subscription.rb
@@ -21,7 +21,7 @@ module ActivityNotification
 
         field :key,                       :string
         field :subscribing,               :boolean, default: ActivityNotification.config.subscribe_as_default
-        field :subscribing_to_email,      :boolean, default: ActivityNotification.config.subscribe_as_default
+        field :subscribing_to_email,      :boolean, default: ActivityNotification.config.subscribe_to_email_as_default
         field :subscribed_at,             :datetime
         field :unsubscribed_at,           :datetime
         field :subscribed_to_email_at,    :datetime

--- a/lib/activity_notification/orm/mongoid/subscription.rb
+++ b/lib/activity_notification/orm/mongoid/subscription.rb
@@ -20,7 +20,7 @@ module ActivityNotification
 
         field :key,                       type: String
         field :subscribing,               type: Boolean, default: ActivityNotification.config.subscribe_as_default
-        field :subscribing_to_email,      type: Boolean, default: ActivityNotification.config.subscribe_as_default
+        field :subscribing_to_email,      type: Boolean, default: ActivityNotification.config.subscribe_to_email_as_default
         field :subscribed_at,             type: DateTime
         field :unsubscribed_at,           type: DateTime
         field :subscribed_to_email_at,    type: DateTime

--- a/lib/generators/templates/activity_notification.rb
+++ b/lib/generators/templates/activity_notification.rb
@@ -31,6 +31,16 @@ ActivityNotification.configure do |config|
   # Set false when you want to unsubscribe to any notifications as default.
   config.subscribe_as_default = true
 
+  # Configure default email subscription value to use when the subscription record does not configured.
+  # Note that you can configure them for each method calling as default argument.
+  # Set false when you want to unsubscribe to email notifications as default.
+  # config.subscribe_to_email_as_default = true
+
+  # Configure default optional target subscription value to use when the subscription record does not configured.
+  # Note that you can configure them for each method calling as default argument.
+  # Set false when you want to unsubscribe to optinal target notifications as default.
+  # config.subscribe_to_optional_targets_as_default = true
+
   # Configure the e-mail address which will be shown in ActivityNotification::Mailer,
   # note that it will be overwritten if you use your own mailer class with default "from" parameter.
   config.mailer_sender = 'please-change-me-at-config-initializers-activity_notification@example.com'

--- a/spec/concerns/apis/subscription_api_spec.rb
+++ b/spec/concerns/apis/subscription_api_spec.rb
@@ -210,7 +210,7 @@ shared_examples_for :subscription_api do
         test_instance.update(optional_targets: {})
       end
 
-      context "without configured optional target subscpriotion" do
+      context "without configured optional target subscription" do
         context "without subscribe_as_default argument" do
           context "with true as ActivityNotification.config.subscribe_as_default" do
             it "returns true" do
@@ -218,6 +218,28 @@ shared_examples_for :subscription_api do
               ActivityNotification.config.subscribe_as_default = true
               expect(test_instance.subscribing_to_optional_target?(:console_output)).to be_truthy
               ActivityNotification.config.subscribe_as_default = subscribe_as_default
+            end
+
+            context "with true as ActivityNotification.config.subscribe_to_optional_targets_as_default" do
+              it "returns true" do
+                subscribe_as_default = ActivityNotification.config.subscribe_as_default
+                ActivityNotification.config.subscribe_as_default = true
+                ActivityNotification.config.subscribe_to_optional_targets_as_default = true
+                expect(test_instance.subscribing_to_optional_target?(:console_output)).to be_truthy
+                ActivityNotification.config.subscribe_as_default = subscribe_as_default
+                ActivityNotification.config.subscribe_to_optional_targets_as_default = nil
+              end
+            end
+
+            context "with false as ActivityNotification.config.subscribe_to_optional_targets_as_default" do
+              it "returns false" do
+                subscribe_as_default = ActivityNotification.config.subscribe_as_default
+                ActivityNotification.config.subscribe_as_default = true
+                ActivityNotification.config.subscribe_to_optional_targets_as_default = false
+                expect(test_instance.subscribing_to_optional_target?(:console_output)).to be_falsey
+                ActivityNotification.config.subscribe_as_default = subscribe_as_default
+                ActivityNotification.config.subscribe_to_optional_targets_as_default = nil
+              end
             end
           end
 
@@ -228,11 +250,33 @@ shared_examples_for :subscription_api do
               expect(test_instance.subscribing_to_optional_target?(:console_output)).to be_falsey
               ActivityNotification.config.subscribe_as_default = subscribe_as_default
             end
+
+            context "with true as ActivityNotification.config.subscribe_to_optional_targets_as_default" do
+              it "returns false" do
+                subscribe_as_default = ActivityNotification.config.subscribe_as_default
+                ActivityNotification.config.subscribe_as_default = false
+                ActivityNotification.config.subscribe_to_optional_targets_as_default = true
+                expect(test_instance.subscribing_to_optional_target?(:console_output)).to be_falsey
+                ActivityNotification.config.subscribe_as_default = subscribe_as_default
+                ActivityNotification.config.subscribe_to_optional_targets_as_default = nil
+              end
+            end
+
+            context "with false as ActivityNotification.config.subscribe_to_optional_targets_as_default" do
+              it "returns false" do
+                subscribe_as_default = ActivityNotification.config.subscribe_as_default
+                ActivityNotification.config.subscribe_as_default = false
+                ActivityNotification.config.subscribe_to_optional_targets_as_default = false
+                expect(test_instance.subscribing_to_optional_target?(:console_output)).to be_falsey
+                ActivityNotification.config.subscribe_as_default = subscribe_as_default
+                ActivityNotification.config.subscribe_to_optional_targets_as_default = nil
+              end
+            end
           end
         end
       end
 
-      context "with configured subscpriotion" do
+      context "with configured subscription" do
         context "subscribing to optional target" do
           it "returns true" do
             test_instance.subscribe_to_optional_target(:console_output)

--- a/spec/concerns/apis/subscription_api_spec.rb
+++ b/spec/concerns/apis/subscription_api_spec.rb
@@ -45,6 +45,41 @@ shared_examples_for :subscription_api do
           expect(test_instance.subscribed_to_email_at).to         eq(Time.current)
           Timecop.return
         end
+
+        context "with true as ActivityNotification.config.subscribe_to_email_as_default" do
+          it "subscribe with current time" do
+            ActivityNotification.config.subscribe_to_email_as_default = true
+
+            expect(test_instance.subscribing?).to                   eq(false)
+            expect(test_instance.subscribing_to_email?).to          eq(false)
+            Timecop.freeze(Time.at(Time.now.to_i))
+            test_instance.subscribe
+            expect(test_instance.subscribing?).to                   eq(true)
+            expect(test_instance.subscribing_to_email?).to          eq(true)
+            expect(test_instance.subscribed_at).to                  eq(Time.current)
+            expect(test_instance.subscribed_to_email_at).to         eq(Time.current)
+            Timecop.return
+
+            ActivityNotification.config.subscribe_to_email_as_default = nil
+          end
+        end
+
+        context "with false as ActivityNotification.config.subscribe_to_email_as_default" do
+          it "subscribe with current time" do
+            ActivityNotification.config.subscribe_to_email_as_default = false
+
+            expect(test_instance.subscribing?).to                   eq(false)
+            expect(test_instance.subscribing_to_email?).to          eq(false)
+            Timecop.freeze(Time.at(Time.now.to_i))
+            test_instance.subscribe
+            expect(test_instance.subscribing?).to                   eq(true)
+            expect(test_instance.subscribing_to_email?).to          eq(false)
+            expect(test_instance.subscribed_at).to                  eq(Time.current)
+            Timecop.return
+
+            ActivityNotification.config.subscribe_to_email_as_default = nil
+          end
+        end
       end
 
       context "with subscribed_at option" do
@@ -57,6 +92,39 @@ shared_examples_for :subscription_api do
           expect(test_instance.subscribing_to_email?).to          eq(true)
           expect(test_instance.subscribed_at.to_i).to             eq(subscribed_at.to_i)
           expect(test_instance.subscribed_to_email_at.to_i).to    eq(subscribed_at.to_i)
+        end
+
+        context "with true as ActivityNotification.config.subscribe_to_email_as_default" do
+          it "subscribe with current time" do
+            ActivityNotification.config.subscribe_to_email_as_default = true
+
+            expect(test_instance.subscribing?).to                   eq(false)
+            expect(test_instance.subscribing_to_email?).to          eq(false)
+            subscribed_at = Time.current - 1.months
+            test_instance.subscribe(subscribed_at: subscribed_at)
+            expect(test_instance.subscribing?).to                   eq(true)
+            expect(test_instance.subscribing_to_email?).to          eq(true)
+            expect(test_instance.subscribed_at.to_i).to             eq(subscribed_at.to_i)
+            expect(test_instance.subscribed_to_email_at.to_i).to    eq(subscribed_at.to_i)
+
+            ActivityNotification.config.subscribe_to_email_as_default = nil
+          end
+        end
+
+        context "with false as ActivityNotification.config.subscribe_to_email_as_default" do
+          it "subscribe with current time" do
+            ActivityNotification.config.subscribe_to_email_as_default = false
+
+            expect(test_instance.subscribing?).to                   eq(false)
+            expect(test_instance.subscribing_to_email?).to          eq(false)
+            subscribed_at = Time.current - 1.months
+            test_instance.subscribe(subscribed_at: subscribed_at)
+            expect(test_instance.subscribing?).to                   eq(true)
+            expect(test_instance.subscribing_to_email?).to          eq(false)
+            expect(test_instance.subscribed_at.to_i).to             eq(subscribed_at.to_i)
+
+            ActivityNotification.config.subscribe_to_email_as_default = nil
+          end
         end
       end
 
@@ -78,6 +146,36 @@ shared_examples_for :subscription_api do
           test_instance.subscribe
           expect(test_instance.subscribing?).to                                     eq(true)
           expect(test_instance.subscribing_to_optional_target?(:console_output)).to eq(true)
+        end
+
+        context "with true as ActivityNotification.config.subscribe_to_optional_targets_as_default" do
+          it "also subscribes to optional targets" do
+            ActivityNotification.config.subscribe_to_optional_targets_as_default = true
+
+            test_instance.unsubscribe_to_optional_target(:console_output)
+            expect(test_instance.subscribing?).to                                     eq(false)
+            expect(test_instance.subscribing_to_optional_target?(:console_output)).to eq(false)
+            test_instance.subscribe
+            expect(test_instance.subscribing?).to                                     eq(true)
+            expect(test_instance.subscribing_to_optional_target?(:console_output)).to eq(true)
+
+            ActivityNotification.config.subscribe_to_optional_targets_as_default = nil
+          end
+        end
+
+        context "with false as ActivityNotification.config.subscribe_to_optional_targets_as_default" do
+          it "does not subscribe to optional targets" do
+            ActivityNotification.config.subscribe_to_optional_targets_as_default = false
+
+            test_instance.unsubscribe_to_optional_target(:console_output)
+            expect(test_instance.subscribing?).to                                     eq(false)
+            expect(test_instance.subscribing_to_optional_target?(:console_output)).to eq(false)
+            test_instance.subscribe
+            expect(test_instance.subscribing?).to                                     eq(true)
+            expect(test_instance.subscribing_to_optional_target?(:console_output)).to eq(false)
+
+            ActivityNotification.config.subscribe_to_optional_targets_as_default = nil
+          end
         end
       end
 

--- a/spec/concerns/models/subscriber_spec.rb
+++ b/spec/concerns/models/subscriber_spec.rb
@@ -86,7 +86,64 @@ shared_examples_for :subscriber do
           new_subscription = test_instance.create_subscription(params)
           expect(new_subscription.subscribing?).to           be_truthy
           expect(new_subscription.subscribing_to_email?).to  be_truthy
+          expect(new_subscription.subscribing_to_optional_target?(:console_output)).to be_truthy
           expect(test_instance.subscriptions.reload.size).to eq(1)
+        end
+
+        context "with true as ActivityNotification.config.subscribe_to_email_as_default" do
+          it "creates a new subscription" do
+            ActivityNotification.config.subscribe_to_email_as_default = true
+
+            params = { key: 'key_1' }
+            new_subscription = test_instance.create_subscription(params)
+            expect(new_subscription.subscribing?).to           be_truthy
+            expect(new_subscription.subscribing_to_email?).to  be_truthy
+            expect(test_instance.subscriptions.reload.size).to eq(1)
+
+            ActivityNotification.config.subscribe_to_email_as_default = nil
+          end
+        end
+
+        context "with false as ActivityNotification.config.subscribe_to_email_as_default" do
+          it "creates a new subscription" do
+            ActivityNotification.config.subscribe_to_email_as_default = false
+
+            params = { key: 'key_1' }
+            new_subscription = test_instance.create_subscription(params)
+            expect(new_subscription.subscribing?).to           be_truthy
+            expect(new_subscription.subscribing_to_email?).to  be_falsey
+            expect(test_instance.subscriptions.reload.size).to eq(1)
+
+            ActivityNotification.config.subscribe_to_email_as_default = nil
+          end
+        end
+
+        context "with true as ActivityNotification.config.subscribe_to_optional_targets_as_default" do
+          it "creates a new subscription" do
+            ActivityNotification.config.subscribe_to_optional_targets_as_default = true
+
+            params = { key: 'key_1' }
+            new_subscription = test_instance.create_subscription(params)
+            expect(new_subscription.subscribing?).to           be_truthy
+            expect(new_subscription.subscribing_to_optional_target?(:console_output)).to be_truthy
+            expect(test_instance.subscriptions.reload.size).to eq(1)
+
+            ActivityNotification.config.subscribe_to_optional_targets_as_default = nil
+          end
+        end
+
+        context "with false as ActivityNotification.config.subscribe_to_optional_targets_as_default" do
+          it "creates a new subscription" do
+            ActivityNotification.config.subscribe_to_optional_targets_as_default = false
+
+            params = { key: 'key_1' }
+            new_subscription = test_instance.create_subscription(params)
+            expect(new_subscription.subscribing?).to           be_truthy
+            expect(new_subscription.subscribing_to_optional_target?(:console_output)).to be_falsey
+            expect(test_instance.subscriptions.reload.size).to eq(1)
+
+            ActivityNotification.config.subscribe_to_optional_targets_as_default = nil
+          end
         end
       end
 
@@ -97,6 +154,34 @@ shared_examples_for :subscriber do
           expect(new_subscription.subscribing?).to           be_falsey
           expect(new_subscription.subscribing_to_email?).to  be_falsey
           expect(test_instance.subscriptions.reload.size).to eq(1)
+        end
+
+        context "with true as ActivityNotification.config.subscribe_to_email_as_default" do
+          it "creates a new subscription" do
+            ActivityNotification.config.subscribe_to_email_as_default = true
+
+            params = { key: 'key_1', subscribing: false }
+            new_subscription = test_instance.create_subscription(params)
+            expect(new_subscription.subscribing?).to           be_falsey
+            expect(new_subscription.subscribing_to_email?).to  be_falsey
+            expect(test_instance.subscriptions.reload.size).to eq(1)
+
+            ActivityNotification.config.subscribe_to_email_as_default = nil
+          end
+        end
+
+        context "with false as ActivityNotification.config.subscribe_to_email_as_default" do
+          it "creates a new subscription" do
+            ActivityNotification.config.subscribe_to_email_as_default = false
+
+            params = { key: 'key_1', subscribing: false }
+            new_subscription = test_instance.create_subscription(params)
+            expect(new_subscription.subscribing?).to           be_falsey
+            expect(new_subscription.subscribing_to_email?).to  be_falsey
+            expect(test_instance.subscriptions.reload.size).to eq(1)
+
+            ActivityNotification.config.subscribe_to_email_as_default = nil
+          end
         end
       end
 

--- a/spec/concerns/models/subscriber_spec.rb
+++ b/spec/concerns/models/subscriber_spec.rb
@@ -462,7 +462,7 @@ shared_examples_for :subscriber do
           described_class._notification_subscription_allowed = true
         end
 
-        context "without configured subscpriotion" do
+        context "without configured subscription" do
           context "without subscribe_as_default argument" do
             context "with true as ActivityNotification.config.subscribe_as_default" do
               it "returns true" do
@@ -484,7 +484,7 @@ shared_examples_for :subscriber do
           end
         end
 
-        context "with configured subscpriotion" do
+        context "with configured subscription" do
           context "subscribing to notification" do
             it "returns true" do
               subscription = test_instance.create_subscription(key: @test_key)
@@ -521,7 +521,7 @@ shared_examples_for :subscriber do
           described_class._notification_subscription_allowed = true
         end
 
-        context "without configured subscpriotion" do
+        context "without configured subscription" do
           context "without subscribe_as_default argument" do
             context "with true as ActivityNotification.config.subscribe_as_default" do
               it "returns true" do
@@ -529,6 +529,28 @@ shared_examples_for :subscriber do
                 ActivityNotification.config.subscribe_as_default = true
                 expect(test_instance.subscribes_to_notification_email?(@test_key)).to be_truthy
                 ActivityNotification.config.subscribe_as_default = subscribe_as_default
+              end
+
+              context "with true as ActivityNotification.config.subscribe_to_email_as_default" do
+                it "returns true" do
+                  subscribe_as_default = ActivityNotification.config.subscribe_as_default
+                  ActivityNotification.config.subscribe_as_default = true
+                  ActivityNotification.config.subscribe_to_email_as_default = true
+                  expect(test_instance.subscribes_to_notification_email?(@test_key)).to be_truthy
+                  ActivityNotification.config.subscribe_as_default = subscribe_as_default
+                  ActivityNotification.config.subscribe_to_email_as_default = nil
+                end
+              end
+
+              context "with false as ActivityNotification.config.subscribe_to_email_as_default" do
+                it "returns false" do
+                  subscribe_as_default = ActivityNotification.config.subscribe_as_default
+                  ActivityNotification.config.subscribe_as_default = true
+                  ActivityNotification.config.subscribe_to_email_as_default = false
+                  expect(test_instance.subscribes_to_notification_email?(@test_key)).to be_falsey
+                  ActivityNotification.config.subscribe_as_default = subscribe_as_default
+                  ActivityNotification.config.subscribe_to_email_as_default = nil
+                end
               end
             end
 
@@ -539,11 +561,33 @@ shared_examples_for :subscriber do
                 expect(test_instance.subscribes_to_notification_email?(@test_key)).to be_falsey
                 ActivityNotification.config.subscribe_as_default = subscribe_as_default
               end
+
+              context "with true as ActivityNotification.config.subscribe_to_email_as_default" do
+                it "returns false" do
+                  subscribe_as_default = ActivityNotification.config.subscribe_as_default
+                  ActivityNotification.config.subscribe_as_default = false
+                  ActivityNotification.config.subscribe_to_email_as_default = true
+                  expect(test_instance.subscribes_to_notification_email?(@test_key)).to be_falsey
+                  ActivityNotification.config.subscribe_as_default = subscribe_as_default
+                  ActivityNotification.config.subscribe_to_email_as_default = nil
+                end
+              end
+
+              context "with false as ActivityNotification.config.subscribe_to_email_as_default" do
+                it "returns false" do
+                  subscribe_as_default = ActivityNotification.config.subscribe_as_default
+                  ActivityNotification.config.subscribe_as_default = false
+                  ActivityNotification.config.subscribe_to_email_as_default = false
+                  expect(test_instance.subscribes_to_notification_email?(@test_key)).to be_falsey
+                  ActivityNotification.config.subscribe_as_default = subscribe_as_default
+                  ActivityNotification.config.subscribe_to_email_as_default = nil
+                end
+              end
             end
           end
         end
 
-        context "with configured subscpriotion" do
+        context "with configured subscription" do
           context "subscribing to notification email" do
             it "returns true" do
               subscription = test_instance.create_subscription(key: @test_key)
@@ -581,7 +625,7 @@ shared_examples_for :subscriber do
           described_class._notification_subscription_allowed = true
         end
 
-        context "without configured subscpriotion" do
+        context "without configured subscription" do
           context "without subscribe_as_default argument" do
             context "with true as ActivityNotification.config.subscribe_as_default" do
               it "returns true" do
@@ -589,6 +633,28 @@ shared_examples_for :subscriber do
                 ActivityNotification.config.subscribe_as_default = true
                 expect(test_instance.subscribes_to_optional_target?(@test_key, @optional_target_name)).to be_truthy
                 ActivityNotification.config.subscribe_as_default = subscribe_as_default
+              end
+
+              context "with true as ActivityNotification.config.subscribe_to_optional_targets_as_default" do
+                it "returns true" do
+                  subscribe_as_default = ActivityNotification.config.subscribe_as_default
+                  ActivityNotification.config.subscribe_as_default = true
+                  ActivityNotification.config.subscribe_to_optional_targets_as_default = true
+                  expect(test_instance.subscribes_to_optional_target?(@test_key, @optional_target_name)).to be_truthy
+                  ActivityNotification.config.subscribe_as_default = subscribe_as_default
+                  ActivityNotification.config.subscribe_to_optional_targets_as_default = nil
+                end
+              end
+
+              context "with false as ActivityNotification.config.subscribe_to_optional_targets_as_default" do
+                it "returns false" do
+                  subscribe_as_default = ActivityNotification.config.subscribe_as_default
+                  ActivityNotification.config.subscribe_as_default = true
+                  ActivityNotification.config.subscribe_to_optional_targets_as_default = false
+                  expect(test_instance.subscribes_to_optional_target?(@test_key, @optional_target_name)).to be_falsey
+                  ActivityNotification.config.subscribe_as_default = subscribe_as_default
+                  ActivityNotification.config.subscribe_to_optional_targets_as_default = nil
+                end
               end
             end
 
@@ -599,11 +665,33 @@ shared_examples_for :subscriber do
                 expect(test_instance.subscribes_to_optional_target?(@test_key, @optional_target_name)).to be_falsey
                 ActivityNotification.config.subscribe_as_default = subscribe_as_default
               end
+
+              context "with true as ActivityNotification.config.subscribe_to_optional_targets_as_default" do
+                it "returns false" do
+                  subscribe_as_default = ActivityNotification.config.subscribe_as_default
+                  ActivityNotification.config.subscribe_as_default = false
+                  ActivityNotification.config.subscribe_to_optional_targets_as_default = true
+                  expect(test_instance.subscribes_to_optional_target?(@test_key, @optional_target_name)).to be_falsey
+                  ActivityNotification.config.subscribe_as_default = subscribe_as_default
+                  ActivityNotification.config.subscribe_to_optional_targets_as_default = nil
+                end
+              end
+
+              context "with false as ActivityNotification.config.subscribe_to_optional_targets_as_default" do
+                it "returns false" do
+                  subscribe_as_default = ActivityNotification.config.subscribe_as_default
+                  ActivityNotification.config.subscribe_as_default = false
+                  ActivityNotification.config.subscribe_to_optional_targets_as_default = false
+                  expect(test_instance.subscribes_to_optional_target?(@test_key, @optional_target_name)).to be_falsey
+                  ActivityNotification.config.subscribe_as_default = subscribe_as_default
+                  ActivityNotification.config.subscribe_to_optional_targets_as_default = nil
+                end
+              end
             end
           end
         end
 
-        context "with configured subscpriotion" do
+        context "with configured subscription" do
           context "subscribing to the specified optional target" do
             it "returns true" do
               subscription = test_instance.create_subscription(key: @test_key, optional_targets: { ActivityNotification::Subscription.to_optional_target_key(@optional_target_name) => true })

--- a/spec/rails_app/config/initializers/activity_notification.rb
+++ b/spec/rails_app/config/initializers/activity_notification.rb
@@ -31,6 +31,16 @@ ActivityNotification.configure do |config|
   # Set false when you want to unsubscribe to any notifications as default.
   config.subscribe_as_default = true
 
+  # Configure default email subscription value to use when the subscription record does not configured.
+  # Note that you can configure them for each method calling as default argument.
+  # Set false when you want to unsubscribe to email notifications as default.
+  # config.subscribe_to_email_as_default = true
+
+  # Configure default optional target subscription value to use when the subscription record does not configured.
+  # Note that you can configure them for each method calling as default argument.
+  # Set false when you want to unsubscribe to optinal target notifications as default.
+  # config.subscribe_to_optional_targets_as_default = true
+
   # Configure the e-mail address which will be shown in ActivityNotification::Mailer,
   # note that it will be overwritten if you use your own mailer class with default "from" parameter.
   config.mailer_sender = 'please-change-me-at-config-initializers-activity_notification@example.com'


### PR DESCRIPTION
**Issue #, if available**: #159

### Summary

I added two new entry to `ActivityNotification::Config`, `subscribe_to_email_as_default` to change default subscriptions for emails (if you want to differ from `subscribe_as_default`) and `subscribe_to_optional_targets_as_default` to change default subscriptions for optional targets. Then I went through the gem, looked for usages of `subscribe_as_default` and changed them to use the new configs. After introducing the new defaults to every reasonable place, the tests remained green (that was the expected result as the new configs have a fallback to the common default)

### Other Information

I still need to do a few steps to finish the PR, but an initial review would be nice
- [x] Keep all existing specs as they are
- [x] Add new specs to check the behavior of the new configs
- [x] Make some manual tests on example rails app