### PR TITLE
Allow custom association name for subscriptions

### DIFF
--- a/spec/concerns/models/subscriber_spec.rb
+++ b/spec/concerns/models/subscriber_spec.rb
@@ -17,6 +17,17 @@ shared_examples_for :subscriber do
       expect(test_instance.subscriptions.latest_order.first).to   eq(subscription_2)
       expect(test_instance.subscriptions.latest_order.to_a).to    eq(ActivityNotification::Subscription.filtered_by_target(test_instance).latest_order.to_a)
     end
+
+    it "has many subscriptions with custom association name" do
+      ActivityNotification.config.subscription_table_name = 'notifications_subscriptions'
+
+      subscription_1 = create(:subscription, target: test_instance, key: 'subscription_key_1')
+      subscription_2 = create(:subscription, target: test_instance, key: 'subscription_key_2', created_at: subscription_1.created_at + 10.second)
+      expect(test_instance.notifications_subscriptions.count).to                eq(2)
+      expect(test_instance.notifications_subscriptions.earliest_order.first).to eq(subscription_1)
+      expect(test_instance.notifications_subscriptions.latest_order.first).to   eq(subscription_2)
+      expect(test_instance.notifications_subscriptions.latest_order.to_a).to    eq(ActivityNotification::Subscription.filtered_by_target(test_instance).latest_order.to_a)
+    end
   end    
 
   describe "as public class methods" do


### PR DESCRIPTION
**Issue #161, if available**:

### Summary

Right now I just added a failing spec for custom association name. I assumed we can use the same config for custom subscriptions table, but of course I'll let you decide this @simukappu 

There are many methods inside the subscriber.rb that depends on the default `subscriptions` association name. As said, if anyone attaches this concern to a model that has subscriptions associations, it breaks functionality

Please give me instructions on the direction you prefer to move forward about this
Thanks
