### PR TITLE
Rails 7.1 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     branches:
-      - '**'
+      - 'master'
       - '!images'
   pull_request:
     branches:
@@ -23,6 +23,7 @@ jobs:
           - gemfiles/Gemfile.rails-6.0
           - gemfiles/Gemfile.rails-6.1
           - gemfiles/Gemfile.rails-7.0
+          - gemfiles/Gemfile.rails-7.1
         orm:
           - active_record
           - mongoid
@@ -36,21 +37,23 @@ jobs:
           - gemfile: gemfiles/Gemfile.rails-5.2
             ruby-version: 2.7.7
           - gemfile: gemfiles/Gemfile.rails-6.0
-            ruby-version: 3.2.1
+            ruby-version: 2.7.7
           - gemfile: gemfiles/Gemfile.rails-6.1
-            ruby-version: 3.2.1
+            ruby-version: 2.7.7
           - gemfile: gemfiles/Gemfile.rails-7.0
-            ruby-version: 3.2.1
+            ruby-version: 3.1.6
+          - gemfile: gemfiles/Gemfile.rails-7.1
+            ruby-version: 3.2.4
           - gemfile: Gemfile
-            ruby-version: 3.2.1
+            ruby-version: 3.3.3
             orm: active_record
             test-db: mysql
           - gemfile: Gemfile
-            ruby-version: 3.2.1
+            ruby-version: 3.3.3
             orm: active_record
             test-db: postgresql
           - gemfile: Gemfile
-            ruby-version: 3.2.1
+            ruby-version: 3.3.3
             orm: mongoid
             test-db: mongodb
           - gemfile: Gemfile
@@ -63,6 +66,8 @@ jobs:
           - gemfile: gemfiles/Gemfile.rails-6.1
             orm: dynamoid
           - gemfile: gemfiles/Gemfile.rails-7.0
+            orm: dynamoid
+          - gemfile: gemfiles/Gemfile.rails-7.1
             orm: dynamoid
 
     env:
@@ -100,7 +105,7 @@ jobs:
         options: --health-cmd mongosh --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -2,16 +2,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rails', '~> 7.0.0'
+gem 'rails', '~> 7.1.0'
 
 group :production do
   gem 'sprockets-rails'
   gem 'puma'
   gem 'pg'
   gem 'devise'
-  # gem 'devise_token_auth'
-  # https://github.com/lynndylanhurley/devise_token_auth/pull/1517
-  gem 'devise_token_auth', git: 'https://github.com/lynndylanhurley/devise_token_auth.git'
+  gem 'devise_token_auth'
 end
 
 group :development do

--- a/activity_notification.gemspec
+++ b/activity_notification.gemspec
@@ -20,16 +20,16 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = '>= 2.1.0'
 
-  s.add_dependency 'railties', '>= 5.0.0', '< 7.1'
+  s.add_dependency 'railties', '>= 5.0.0', '< 7.2'
   s.add_dependency 'i18n', '>= 0.5.0'
   s.add_dependency 'jquery-rails', '>= 3.1.1'
   s.add_dependency 'swagger-blocks', '>= 3.0.0'
 
   s.add_development_dependency 'puma', '>= 3.12.0'
-  s.add_development_dependency 'sqlite3', '>= 1.3.13'
+  s.add_development_dependency 'sqlite3', '>= 1.3.13', '< 2.0'
   s.add_development_dependency 'mysql2', '>= 0.5.2'
   s.add_development_dependency 'pg', '>= 1.0.0'
-  s.add_development_dependency 'mongoid', '>= 4.0.0'
+  s.add_development_dependency 'mongoid', '>= 4.0.0', '< 9.0'
   s.add_development_dependency 'dynamoid', '3.1.0'
   s.add_development_dependency 'rspec-rails', '>= 3.8.0'
   s.add_development_dependency 'factory_bot_rails', '>= 4.11.0', '< 5.0.0'

--- a/gemfiles/Gemfile.rails-7.1
+++ b/gemfiles/Gemfile.rails-7.1
@@ -2,7 +2,9 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'rails', '~> 5.1.0'
+gem 'rails', '~> 7.1.0'
+gem 'sprockets-rails'
+gem 'devise_token_auth'
 
 group :development do
   gem 'bullet'
@@ -10,16 +12,13 @@ group :development do
 end
 
 group :test do
-  gem 'rspec-rails', '< 4.0.0'
   gem 'rails-controller-testing'
-  gem 'action-cable-testing'
   gem 'ammeter'
   gem 'timecop'
   gem 'committee'
   gem 'committee-rails', '< 0.6'
   # gem 'coveralls', require: false
   gem 'coveralls_reborn', require: false
-  gem 'mongoid', '>= 4.0.0', '< 8.0'
 end
 
 gem 'dotenv-rails', groups: [:development, :test]

--- a/spec/concerns/renderable_spec.rb
+++ b/spec/concerns/renderable_spec.rb
@@ -77,7 +77,7 @@ shared_examples_for :renderable do
               test_instance.target = create(:admin)
               test_instance.key = "notification.#{simple_text_key}"
               expect(test_instance.text)
-                .to eq("translation missing: en.notification.admin.#{simple_text_key}.text")
+                .to eq("Translation missing: en.notification.admin.#{simple_text_key}.text")
             end
           end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,7 @@ def clean_database
 end
 
 RSpec.configure do |config|
+  config.expect_with  :minitest, :rspec
   config.include FactoryBot::Syntax::Methods
   config.before(:each) do
     FactoryBot.reload


### PR DESCRIPTION
For #173.

I would respectfully suggest that 6.0 and lower be dropped soon.  Rails 7.2 is in beta and 8 is in heavy development.  This would also drop dynamoid support.