### PR TITLE
fix serialize arguments for Rails 7.1+

### DIFF
--- a/lib/activity_notification/orm/active_record/notification.rb
+++ b/lib/activity_notification/orm/active_record/notification.rb
@@ -45,7 +45,11 @@ module ActivityNotification
         belongs_to :notifier,      polymorphic: true, optional: true
 
         # Serialize parameters Hash
-        serialize  :parameters, Hash
+        if Rails.gem_version >= Gem::Version.new('7.1')
+          serialize  :parameters, type: Hash, coder: YAML
+        else
+          serialize  :parameters, Hash
+        end
 
         validates  :target,        presence: true
         validates  :notifiable,    presence: true

--- a/lib/activity_notification/orm/active_record/subscription.rb
+++ b/lib/activity_notification/orm/active_record/subscription.rb
@@ -14,7 +14,11 @@ module ActivityNotification
         belongs_to :target,               polymorphic: true
 
         # Serialize parameters Hash
-        serialize  :optional_targets, Hash
+        if Rails.gem_version >= Gem::Version.new('7.1')
+          serialize  :optional_targets, type: Hash, coder: YAML
+        else
+          serialize  :optional_targets, Hash
+        end
 
         validates  :target,               presence: true
         validates  :key,                  presence: true, uniqueness: { scope: :target }


### PR DESCRIPTION
**Issue #178**:

### Summary

Rails deprecated passing the type as a second argument and no longer defaults to YAML as the default serializer:

https://github.com/rails/rails/blob/77dfa65392e672ac83ced68cda37d5770c16ea6c/activerecord/CHANGELOG.md?plain=1#L1262

https://github.com/rails/rails/blob/77dfa65392e672ac83ced68cda37d5770c16ea6c/activerecord/CHANGELOG.md?plain=1#L1282

### Other Information

I did not realize this until I did config.load_defaults 7.1 .  It may work in non-engine scenarios (see related rails issue https://github.com/rails/rails/issues/52336), but this solves it for 7.1 and the upcoming 7.2

#173 original PR