### PR TITLE
Add skip_validation option to open! method for notification handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ This sample application works with *activity_notification* REST API backend.
     - [Rendering notifications](/docs/Setup.md#rendering-notifications)
     - [Notification views](/docs/Setup.md#notification-views)
     - [i18n for notifications](/docs/Setup.md#i18n-for-notifications)
+    - [Managing notifications](/docs/Setup.md#managing-notifications)
   - [Customizing controllers (optional)](/docs/Setup.md#customizing-controllers-optional)
 - [Functions](/docs/Functions.md#Functions)
   - [Email notification](/docs/Functions.md#email-notification)
@@ -283,6 +284,25 @@ See [Creating notifications](/docs/Setup.md#creating-notifications) for more det
 *activity_notification* also provides notification views. You can prepare target notifications, render them in your controller, and show them provided or custom notification views.
 
 See [Displaying notifications](/docs/Setup.md#displaying-notifications) for more details.
+
+### Managing notifications
+
+*activity_notification* provides APIs to manage notifications programmatically. You can mark notifications as opened (read), filter them, and perform bulk operations:
+
+```ruby
+# Mark a notification as opened
+notification.open!
+
+# Open with options for better performance or specific behavior
+notification.open!(skip_validation: true)  # Skip validations for better performance
+notification.open!(with_members: true)    # Open including group members
+notification.open!(opened_at: 1.hour.ago)  # Set specific timestamp
+
+# Open all notifications for a user
+ActivityNotification::Notification.open_all_of(current_user)
+```
+
+See [Managing notifications](/docs/Setup.md#managing-notifications) for more details.
 
 ### Run example Rails application
 

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -762,6 +762,49 @@ notification:
 
 This structure is valid for notifications with keys *"notification.comment.reply"* or *"comment.reply"*. As mentioned before, *"notification."* part of the key is optional. In addition for above example, `%{notifier_name}` and `%{article_title}` are used from parameter field in the notification record. Pluralization is supported (but optional) for grouped notifications using the `%{group_notification_count}` value.
 
+#### Managing notifications
+
+*activity_notification* provides several methods to manage notifications programmatically. The most common operation is opening notifications to mark them as read.
+
+##### Opening notifications
+
+You can mark individual notifications as opened (read) using the **open!** method:
+
+```ruby
+# Open a single notification
+notification = current_user.notifications.first
+notification.open!
+
+# Open notification with specific timestamp
+notification.open!(opened_at: 1.hour.ago)
+
+# Open notification with opening group members
+notification.open!(with_members: true)
+
+# Open notification skipping validations when the associated notifiable record may have been deleted
+notification.open!(skip_validation: true)
+```
+
+The **open!** method accepts the following options:
+
+* **:opened_at** (Time) - Time to set as the opened timestamp (defaults to `Time.current`)
+* **:with_members** (Boolean) - Whether to open group member notifications as well (defaults to `false`)
+* **:skip_validation** (Boolean) - Whether to skip ActiveRecord validations when updating (defaults to `false`). Useful when the associated notifiable record may have been deleted but the notification still exists.
+
+You can also open all notifications for a target:
+
+```ruby
+# Open all unopened notifications for a user
+ActivityNotification::Notification.open_all_of(current_user)
+
+# Open notifications with filters
+ActivityNotification::Notification.open_all_of(
+  current_user,
+  filtered_by_type: 'Comment',
+  opened_at: 1.hour.ago
+)
+```
+
 ### Customizing controllers (optional)
 
 If the customization at the views level is not enough, you can customize each controller by following these steps:

--- a/lib/activity_notification/apis/notification_api.rb
+++ b/lib/activity_notification/apis/notification_api.rb
@@ -559,6 +559,7 @@ module ActivityNotification
     # @param [Hash] options Options for opening notifications
     # @option options [DateTime] :opened_at   (Time.current) Time to set to opened_at of the notification record
     # @option options [Boolean] :with_members (true)         If it opens notifications including group members
+    # @option options [Boolean] :skip_validation (true)      If it skips validation of the notification record
     # @return [Integer] Number of opened notification records
     def open!(options = {})
       opened? and return 0
@@ -566,7 +567,7 @@ module ActivityNotification
       with_members = options.has_key?(:with_members) ? options[:with_members] : true
       unopened_member_count = with_members ? group_members.unopened_only.count : 0
       group_members.update_all(opened_at: opened_at) if with_members
-      update(opened_at: opened_at)
+      options[:skip_validation] ? update_column(:opened_at, opened_at) : update(opened_at: opened_at)
       unopened_member_count + 1
     end
 


### PR DESCRIPTION
**Issue #186**:

### Summary
Scenario:
GIVEN I have an unopened notification
WHEN I delete the notifiable associated with the notification, but the notification still exists
AND I click on the notification
THEN the notification should be marked as opened
