### PR TITLE
Allow application to be eager loaded without ActionCable

### DIFF
--- a/app/channels/activity_notification/notification_api_channel.rb
+++ b/app/channels/activity_notification/notification_api_channel.rb
@@ -1,8 +1,8 @@
-if defined?(ActionCable)
-  # Action Cable API channel to subscribe broadcasted notifications.
-  class ActivityNotification::NotificationApiChannel < ActivityNotification::NotificationChannel
-    # ActionCable::Channel::Base#subscribed
-    # @see https://api.rubyonrails.org/classes/ActionCable/Channel/Base.html#method-i-subscribed
+# Action Cable API channel to subscribe broadcasted notifications.
+class ActivityNotification::NotificationApiChannel < ActivityNotification::NotificationChannel
+  if defined?(ActionCable)
+  # ActionCable::Channel::Base#subscribed
+  # @see https://api.rubyonrails.org/classes/ActionCable/Channel/Base.html#method-i-subscribed
     def subscribed
       stream_from "#{ActivityNotification.config.notification_api_channel_prefix}_#{@target.to_class_name}#{ActivityNotification.config.composite_key_delimiter}#{@target.id}"
     rescue

--- a/app/channels/activity_notification/notification_api_with_devise_channel.rb
+++ b/app/channels/activity_notification/notification_api_with_devise_channel.rb
@@ -1,6 +1,6 @@
-if defined?(ActionCable)
-  # Action Cable API channel to subscribe broadcasted notifications with Devise authentication.
-  class ActivityNotification::NotificationApiWithDeviseChannel < ActivityNotification::NotificationApiChannel
+# Action Cable API channel to subscribe broadcasted notifications with Devise authentication.
+class ActivityNotification::NotificationApiWithDeviseChannel < ActivityNotification::NotificationApiChannel
+  if defined?(ActionCable)
     # Include PolymorphicHelpers to resolve string extentions
     include ActivityNotification::PolymorphicHelpers
 

--- a/app/channels/activity_notification/notification_channel.rb
+++ b/app/channels/activity_notification/notification_channel.rb
@@ -34,4 +34,6 @@ if defined?(ActionCable)
         reject if @target.nil? || @target.notification_action_cable_with_devise?
       end
   end
+else
+  class ActivityNotification::NotificationChannel; end
 end

--- a/app/channels/activity_notification/notification_with_devise_channel.rb
+++ b/app/channels/activity_notification/notification_with_devise_channel.rb
@@ -1,6 +1,6 @@
-if defined?(ActionCable)
-  # Action Cable channel to subscribe broadcasted notifications with Devise authentication.
-  class ActivityNotification::NotificationWithDeviseChannel < ActivityNotification::NotificationChannel
+# Action Cable channel to subscribe broadcasted notifications with Devise authentication.
+class ActivityNotification::NotificationWithDeviseChannel < ActivityNotification::NotificationChannel
+  if defined?(ActionCable)
     # Include PolymorphicHelpers to resolve string extentions
     include ActivityNotification::PolymorphicHelpers
 


### PR DESCRIPTION
**Issue #, if available**: https://github.com/simukappu/activity_notification/issues/200

### Summary

<!-- Provide a general description of the code changes in your pull request. 
Were there any bugs you had fixed? If so, mention them.
If these bugs have open GitHub issues, be sure to tag them here as well, to keep the conversation linked together. -->

The files in `app/channels/activity_notification` triggered Zeitwerk errors when the app didn't use ActionCable.
This PR changes these files, so the classes are always defined, no matter if ActioneCable is defined or not.

### Other Information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.

Thank you for contributing to activity_notification! -->