### PR TITLE
Set preview_path correctly in spec/rails_app

### DIFF
--- a/spec/rails_app/config/environments/development.rb
+++ b/spec/rails_app/config/environments/development.rb
@@ -45,7 +45,11 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # For notification email preview
-  config.action_mailer.preview_path = "#{Rails.root}/lib/mailer_previews"
+  if Gem::Version.new("7.1.0") <= Rails.gem_version
+    config.action_mailer.preview_paths << "#{Rails.root}/lib/mailer_previews"
+  else
+    config.action_mailer.preview_path = "#{Rails.root}/lib/mailer_previews"
+  end
 
   # Specifies delivery job for mail
   if Rails::VERSION::MAJOR >= 6


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull request. 
Were there any bugs you had fixed? If so, mention them.
If these bugs have open GitHub issues, be sure to tag them here as well, to keep the conversation linked together. -->
`preview_path` is deprecated since Rails 7.1, we need to use `preview_paths`.


### Other Information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.

Thank you for contributing to activity_notification! -->
See: https://blog.saeloun.com/2024/10/12/rails-7-1-supports-multiple-preview-paths-for-mailers/