### PR TITLE
Doc: add method to send mailer checking by a rule.

### DIFF
--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -47,6 +47,32 @@ class Comment < ActiveRecord::Base
 end
 ```
 
+Another way to change it is overriding `notification_email_allowed?(target, key)` on the notifiable model.
+
+```ruby
+class Comment < ActiveRecord::Base
+  belongs_to :article
+  belongs_to :user
+
+  acts_as_notifiable :users,
+    targets: ->(comment, key) {
+      ([comment.article.user] + comment.article.reload.commented_users.to_a - [comment.user]).uniq
+    },
+    notifiable_path: :article_notifiable_path
+
+  def article_notifiable_path
+    article_path(article)
+  end
+
+  def notification_email_allowed?(target, key)
+    return false if CONDITIONAL
+
+    true
+  end
+end
+```
+
+
 #### Sender configuration
 
 You can configure the notification *"from"* address inside of *activity_notification.rb* in two ways.


### PR DESCRIPTION
### Summary

I was looking for an method to customize when I can send mailer based on my notifiable model attribute and I didn't see on the doc. I needed see on the source file.

So, I would like to add the information on the doc.